### PR TITLE
feat(openresty) compile nginx with stream_realip_module

### DIFF
--- a/Dockerfile.openresty
+++ b/Dockerfile.openresty
@@ -19,6 +19,7 @@ ARG RESTY_CONFIG_OPTIONS="\
   --with-http_stub_status_module \
   --with-http_v2_module \
   --with-stream_ssl_preread_module \
+  --with-stream_realip_module \
   "
 
 LABEL resty_version="${RESTY_VERSION}"


### PR DESCRIPTION
### Summary

Adds `--with-stream_realip_module` to OpenResty `configure` flags.

See also:

- https://github.com/Kong/kong/pull/4163
- https://github.com/Kong/homebrew-kong/pull/86