### PR TITLE
chore(ci) setup travis-ci docker build layer cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_cache:
   # Save docker history of images we want the cache to be available for
   - mkdir -p $HOME/docker
   - docker save -o $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG | tr "\n" " " | tr -d "<missing>")
-  - docker save -o $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar | tr "\n" " " | tr -d "<missing>")
+  - docker save -o $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG | tr "\n" " " | tr -d "<missing>")
   - docker save -o $HOME/docker/kong:fpm.tar $(docker history -q kong:fpm | tr "\n" " " | tr -d "<missing>")
   - ls $HOME/docker/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ before_install:
   # Load cached docker layers
   - ls $HOME/docker/
   - if [[ -f $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar ]]; then docker load -i $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
+  - if [[ -f $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar ]]; then docker load -i $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
   - if [[ -f $HOME/docker/kong:fpm.tar ]]; then docker load -i $HOME/docker/kong:fpm.tar; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,12 @@ before_install:
   - if [[ -f $HOME/docker/kong:fpm.tar ]]; then docker load -i $HOME/docker/kong:fpm.tar; fi
 
 install:
+  - sudo apt-get update && sudo apt-get install -y socat
+  - make setup_tests > /dev/null 2>&1 &
   - git clone https://github.com/Kong/kong.git kong
   - make package-kong
 
 before_script:
-  - sudo apt-get update && sudo apt-get install -y socat & make setup_tests
   - until kubectl get nodes 2>&1 | sed -n 2p | grep -q Ready; do sleep 1 && kubectl get nodes; done
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,15 +38,15 @@ cache:
 
 before_cache:
   # Save docker history of images we want the cache to be available for
-  - >
-    mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}' 
-    | grep kong | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar || docker save -o $HOME/docker/$0.tar $(docker history -q $0 | tr "\n" " " | tr -d "<missing>")'
+  - mkdir -p $HOME/docker && 'test -e $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar || docker save -o $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG | tr "\n" " " | tr -d "<missing>")'
+  - mkdir -p $HOME/docker && 'test -e $HOME/docker/kong:fpm.tar || docker save -o $HOME/docker/kong:fpm.tar $(docker history -q kong:fpm | tr "\n" " " | tr -d "<missing>")'
   - ls $HOME/docker/
 
 before_install:
   # Load cached docker layers
   - ls $HOME/docker/
-  - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar | xargs -I {file} sh -c "docker load -i {file}"; fi
+  - if [[ -f $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar ]]; then docker load -i $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
+  - if [[ -f $HOME/docker/kong:fpm.tar ]]; then docker load -i $HOME/docker/kong:fpm.tar; fi
   - docker images
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ cache:
 before_cache:
   # Save docker history of images we want the cache to be available for
   - mkdir -p $HOME/docker
-  - docker save -o $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG | tr "\n" " " | tr -d "<missing>"
-  - docker save -o $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar | tr "\n" " " | tr -d "<missing>"
-  - docker save -o $HOME/docker/kong:fpm.tar $(docker history -q kong:fpm | tr "\n" " " | tr -d "<missing>"
+  - docker save -o $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG | tr "\n" " " | tr -d "<missing>")
+  - docker save -o $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar | tr "\n" " " | tr -d "<missing>")
+  - docker save -o $HOME/docker/kong:fpm.tar $(docker history -q kong:fpm | tr "\n" " " | tr -d "<missing>")
   - ls $HOME/docker/
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,24 @@ matrix:
     - env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=rolling
     - env: PACKAGE_TYPE=deb RESTY_IMAGE_BASE=debian RESTY_IMAGE_TAG=testing
 
+cache:
+  timeout: 1000
+  directories:
+    - $HOME/docker
+
+before_cache:
+  # Save docker history of images we want the cache to be available for
+  - >
+    mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}' 
+    | grep kong | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar || docker save -o $HOME/docker/$0.tar $(docker history -q $0 | tr "\n" " " | tr -d "<missing>")'
+  - ls $HOME/docker/
+
+before_install:
+  # Load cached docker layers
+  - ls $HOME/docker/
+  - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar | xargs -I {file} sh -c "docker load -i {file}"; fi
+  - docker images
+
 install:
   - git clone https://github.com/Kong/kong.git kong
   - make package-kong

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,10 @@ cache:
 
 before_cache:
   # Save docker history of images we want the cache to be available for
-  - mkdir -p $HOME/docker && 'test -e $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar || docker save -o $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG | tr "\n" " " | tr -d "<missing>")'
-  - mkdir -p $HOME/docker && 'test -e $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar' || docker save -o $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar | tr "\n" " " | tr -d "<missing>")'
-  - mkdir -p $HOME/docker && 'test -e $HOME/docker/kong:fpm.tar || docker save -o $HOME/docker/kong:fpm.tar $(docker history -q kong:fpm | tr "\n" " " | tr -d "<missing>")'
+  - mkdir -p $HOME/docker
+  - docker save -o $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG | tr "\n" " " | tr -d "<missing>"
+  - docker save -o $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar | tr "\n" " " | tr -d "<missing>"
+  - docker save -o $HOME/docker/kong:fpm.tar $(docker history -q kong:fpm | tr "\n" " " | tr -d "<missing>"
   - ls $HOME/docker/
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ cache:
   timeout: 1000
   directories:
     - $HOME/docker
+    - output/build
 
 before_cache:
   # Save docker history of images we want the cache to be available for
@@ -45,17 +46,15 @@ before_cache:
 before_install:
   # Load cached docker layers
   - ls $HOME/docker/
-  - if [[ -f $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar ]]; then docker load -i $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
-  - if [[ -f $HOME/docker/kong:fpm.tar ]]; then docker load -i $HOME/docker/kong:fpm.tar; fi
-  - docker images
+  - if [[ ! -f $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar ]]; then docker load -i $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
+  - if [[ ! -f $HOME/docker/kong:fpm.tar ]]; then docker load -i $HOME/docker/kong:fpm.tar; fi
+  - sudo apt-get update && sudo apt-get install -y socat & make setup_tests&
 
 install:
   - git clone https://github.com/Kong/kong.git kong
   - make package-kong
 
 before_script:
-  - sudo apt-get update && sudo apt-get install -y socat
-  - make setup_tests
   - until kubectl get nodes 2>&1 | sed -n 2p | grep -q Ready; do sleep 1 && kubectl get nodes; done
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,14 @@ before_install:
   # Load cached docker layers
   - ls $HOME/docker/
   - if [[ -f $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar ]]; then docker load -i $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
-  - sudo apt-get update && sudo apt-get install -y socat & make setup_tests&
+  - if [[ -f $HOME/docker/kong:fpm.tar ]]; then docker load -i $HOME/docker/kong:fpm.tar; fi
 
 install:
   - git clone https://github.com/Kong/kong.git kong
   - make package-kong
 
 before_script:
+  - sudo apt-get update && sudo apt-get install -y socat & make setup_tests
   - until kubectl get nodes 2>&1 | sed -n 2p | grep -q Ready; do sleep 1 && kubectl get nodes; done
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,16 @@ cache:
 before_cache:
   # Save docker history of images we want the cache to be available for
   - mkdir -p $HOME/docker && 'test -e $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar || docker save -o $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG | tr "\n" " " | tr -d "<missing>")'
+  - mkdir -p $HOME/docker && 'test -e $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar' || docker save -o $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar $(docker history -q kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar | tr "\n" " " | tr -d "<missing>")'
   - mkdir -p $HOME/docker && 'test -e $HOME/docker/kong:fpm.tar || docker save -o $HOME/docker/kong:fpm.tar $(docker history -q kong:fpm | tr "\n" " " | tr -d "<missing>")'
   - ls $HOME/docker/
 
 before_install:
   # Load cached docker layers
   - ls $HOME/docker/
-  - if [[ ! -f $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar ]]; then docker load -i $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
-  - if [[ ! -f $HOME/docker/kong:fpm.tar ]]; then docker load -i $HOME/docker/kong:fpm.tar; fi
+  - if [[ -f $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar ]]; then docker load -i $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
+  - if [[ -f $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar]]; then docker load -i $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
+  - if [[ -f $HOME/docker/kong:fpm.tar ]]; then docker load -i $HOME/docker/kong:fpm.tar; fi
   - sudo apt-get update && sudo apt-get install -y socat & make setup_tests&
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,6 @@ before_install:
   # Load cached docker layers
   - ls $HOME/docker/
   - if [[ -f $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar ]]; then docker load -i $HOME/docker/kong:$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
-  - if [[ -f $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar]]; then docker load -i $HOME/docker/kong:openresty-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG.tar; fi
-  - if [[ -f $HOME/docker/kong:fpm.tar ]]; then docker load -i $HOME/docker/kong:fpm.tar; fi
   - sudo apt-get update && sudo apt-get install -y socat & make setup_tests&
 
 install:

--- a/Dockerfile.openresty
+++ b/Dockerfile.openresty
@@ -40,20 +40,26 @@ RUN cd /tmp \
     && eval ./config $OPENSSL_OPTIONS shared \
     && make -j${RESTY_J}
 
-ADD https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz /tmp/pcre-${RESTY_PCRE_VERSION}.tar.gz
 ADD https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz /tmp/openresty-${RESTY_VERSION}.tar.gz
-ADD https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz /tmp/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
 ADD https://github.com/Kong/openresty-patches/archive/master.tar.gz /tmp/kong-patches.tar.gz
 
 RUN cd /tmp \
-    && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
-    && tar xzf openresty-${RESTY_VERSION}.tar.gz \
-    && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
+    && tar xzf openresty-${RESTY_VERSION}.tar.gz
+    && tar -xzf kong-patches.tar.gz -C /tmp \
+    && cd /tmp/openresty-${RESTY_VERSION}/bundle/ \
+    && for i in /tmp/openresty-patches-master/patches/${RESTY_VERSION}/*.patch; do patch -p1 < $i; done
 
 RUN cd /tmp/openresty-${RESTY_VERSION} \
     && eval ./configure -j${RESTY_J} ${RESTY_CONFIG_OPTIONS} \
     && make -j${RESTY_J} \
     && make -j${RESTY_J} install DESTDIR=/tmp/build
+
+ADD https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz /tmp/pcre-${RESTY_PCRE_VERSION}.tar.gz
+ADD https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz /tmp/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
+
+RUN cd /tmp
+    && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
+    && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
 
 RUN cd /tmp/luarocks-${RESTY_LUAROCKS_VERSION} \
     && eval ./configure \

--- a/Dockerfile.openresty
+++ b/Dockerfile.openresty
@@ -43,8 +43,15 @@ RUN cd /tmp \
 ADD https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz /tmp/openresty-${RESTY_VERSION}.tar.gz
 ADD https://github.com/Kong/openresty-patches/archive/master.tar.gz /tmp/kong-patches.tar.gz
 
+ADD https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz /tmp/pcre-${RESTY_PCRE_VERSION}.tar.gz
+ADD https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz /tmp/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
+
 RUN cd /tmp \
-    && tar xzf openresty-${RESTY_VERSION}.tar.gz
+    && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
+    && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
+
+RUN cd /tmp \
+    && tar xzf openresty-${RESTY_VERSION}.tar.gz \
     && tar -xzf kong-patches.tar.gz -C /tmp \
     && cd /tmp/openresty-${RESTY_VERSION}/bundle/ \
     && for i in /tmp/openresty-patches-master/patches/${RESTY_VERSION}/*.patch; do patch -p1 < $i; done
@@ -53,13 +60,6 @@ RUN cd /tmp/openresty-${RESTY_VERSION} \
     && eval ./configure -j${RESTY_J} ${RESTY_CONFIG_OPTIONS} \
     && make -j${RESTY_J} \
     && make -j${RESTY_J} install DESTDIR=/tmp/build
-
-ADD https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz /tmp/pcre-${RESTY_PCRE_VERSION}.tar.gz
-ADD https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz /tmp/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
-
-RUN cd /tmp
-    && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
-    && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
 
 RUN cd /tmp/luarocks-${RESTY_LUAROCKS_VERSION} \
     && eval ./configure \

--- a/Dockerfile.openresty
+++ b/Dockerfile.openresty
@@ -30,27 +30,25 @@ LABEL resty_config_options="${RESTY_CONFIG_OPTIONS}"
 
 RUN mkdir -p /tmp/build
 
+ADD https://www.openssl.org/source/openssl-${RESTY_OPENSSL_VERSION}.tar.gz /tmp/openssl-${RESTY_OPENSSL_VERSION}.tar.gz
+
 RUN cd /tmp \
-    && curl -fSL https://www.openssl.org/source/openssl-${RESTY_OPENSSL_VERSION}.tar.gz -o openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
     && tar xzf openssl-${RESTY_OPENSSL_VERSION}.tar.gz \
     && ln -s /tmp/openssl-${RESTY_OPENSSL_VERSION} /tmp/openssl \
-    && curl -fSL https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz -o pcre-${RESTY_PCRE_VERSION}.tar.gz \
-    && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
-    && curl -fSL https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz -o openresty-${RESTY_VERSION}.tar.gz \
-    && tar xzf openresty-${RESTY_VERSION}.tar.gz \
-    && curl -fSL https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz -o luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
-    && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
-
-RUN cd /tmp \
-    && curl -fSL https://github.com/Kong/openresty-patches/archive/master.tar.gz -o kong-patches.tar.gz \
-    && tar -xzf kong-patches.tar.gz -C /tmp \
-    && cd /tmp/openresty-${RESTY_VERSION}/bundle/ \
-    && for i in /tmp/openresty-patches-master/patches/${RESTY_VERSION}/*.patch; do patch -p1 < $i; done
-
-RUN cd /tmp/openssl-${RESTY_OPENSSL_VERSION} \
+    && cd /tmp/openssl-${RESTY_OPENSSL_VERSION} \
     && export OPENSSL_OPTIONS="--prefix=/tmp/build/usr/local/kong --openssldir=/tmp/build/usr/local/kong $OPENSSL_EXTRA_OPTIONS" \
     && eval ./config $OPENSSL_OPTIONS shared \
     && make -j${RESTY_J}
+
+ADD https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz /tmp/pcre-${RESTY_PCRE_VERSION}.tar.gz
+ADD https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz /tmp/openresty-${RESTY_VERSION}.tar.gz
+ADD https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz /tmp/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
+ADD https://github.com/Kong/openresty-patches/archive/master.tar.gz /tmp/kong-patches.tar.gz
+
+RUN cd /tmp \
+    && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
+    && tar xzf openresty-${RESTY_VERSION}.tar.gz \
+    && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
 
 RUN cd /tmp/openresty-${RESTY_VERSION} \
     && eval ./configure -j${RESTY_J} ${RESTY_CONFIG_OPTIONS} \

--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,6 @@ else
 	-t kong:$(RESTY_IMAGE_BASE)-$(RESTY_IMAGE_TAG) .
 endif
 
-
-
 .PHONY: test
 test: build_test_container
 	KONG_VERSION=$(KONG_VERSION) \


### PR DESCRIPTION
use travis-ci file cache to cache build layers associated with some key docker images. Speed improvements aren't that astounding but it will give more reproducible / reliable builds

![capture](https://user-images.githubusercontent.com/697188/52570300-0f5aa100-2de1-11e9-8256-2f0de9a4aa7c.PNG)
![capture1](https://user-images.githubusercontent.com/697188/52570301-0f5aa100-2de1-11e9-8048-38d93697f08f.PNG)
