### PR TITLE
tests(key-auth) add key-auth plugin functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ test: build_test_container
 run_tests:
 	cd test && docker build -t kong:test_runner -f Dockerfile.test_runner .
 	docker run -it --network host -e RESTY_VERSION=$(RESTY_VERSION) -e KONG_VERSION=$(KONG_VERSION) -e ADMIN_URI=$(TEST_ADMIN_URI) -e PROXY_URI=$(TEST_PROXY_URI) ubuntu printenv
-	docker run -it --network host -e RESTY_VERSION=$(RESTY_VERSION) -e KONG_VERSION=$(KONG_VERSION) -e ADMIN_URI=$(TEST_ADMIN_URI) -e PROXY_URI=$(TEST_PROXY_URI) kong:test_runner py.test -p no:logging -p no:warnings test_*.tavern.yaml
+	docker run -it --network host -e RESTY_VERSION=$(RESTY_VERSION) -e KONG_VERSION=$(KONG_VERSION) -e ADMIN_URI=$(TEST_ADMIN_URI) -e PROXY_URI=$(TEST_PROXY_URI) kong:test_runner /bin/bash -c "py.test -p no:logging -p no:warnings test_*.tavern.yaml"
 
 develop_tests:
 	docker run -it --network host --rm -e RESTY_VERSION=$(RESTY_VERSION) -e KONG_VERSION=$(KONG_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,15 @@ test: build_test_container
 run_tests:
 	cd test && docker build -t kong:test_runner -f Dockerfile.test_runner .
 	docker run -it --network host -e RESTY_VERSION=$(RESTY_VERSION) -e KONG_VERSION=$(KONG_VERSION) -e ADMIN_URI=$(TEST_ADMIN_URI) -e PROXY_URI=$(TEST_PROXY_URI) ubuntu printenv
-	docker run -it --network host -e RESTY_VERSION=$(RESTY_VERSION) -e KONG_VERSION=$(KONG_VERSION) -e ADMIN_URI=$(TEST_ADMIN_URI) -e PROXY_URI=$(TEST_PROXY_URI) kong:test_runner py.test test_smoke.tavern.yaml
+	docker run -it --network host -e RESTY_VERSION=$(RESTY_VERSION) -e KONG_VERSION=$(KONG_VERSION) -e ADMIN_URI=$(TEST_ADMIN_URI) -e PROXY_URI=$(TEST_PROXY_URI) kong:test_runner py.test -p no:logging -p no:warnings test_*.tavern.yaml
+
+develop_tests:
+	docker run -it --network host --rm -e RESTY_VERSION=$(RESTY_VERSION) -e KONG_VERSION=$(KONG_VERSION) \
+	-e ADMIN_URI="https://`kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}'`:`kubectl get svc --namespace default kong-kong-admin -o jsonpath='{.spec.ports[0].nodePort}'`" \
+	-e PROXY_URI="http://`kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}'`:`kubectl get svc --namespace default kong-kong-proxy -o jsonpath='{.spec.ports[0].nodePort}'`" \
+	-v $$PWD/test:/app \
+	kong:test_runner /bin/bash
+  
 
 build_test_container:
 	RESTY_IMAGE_BASE=$(RESTY_IMAGE_BASE) \

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+log_cli = true

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -29,5 +29,4 @@ ADMIN_PORT=$(kubectl get svc --namespace default kong-kong-admin -o jsonpath='{.
 echo $ADMIN_PORT
 PROXY_PORT=$(kubectl get svc --namespace default kong-kong-proxy -o jsonpath='{.spec.ports[0].nodePort}')
 echo $PROXY_PORT
-
 TEST_ADMIN_URI=https://$HOST:$ADMIN_PORT TEST_PROXY_URI=http://$HOST:$PROXY_PORT make -f Makefile run_tests

--- a/test/test_plugin-key-auth.tavern.yaml
+++ b/test/test_plugin-key-auth.tavern.yaml
@@ -1,0 +1,137 @@
+---
+test_name: Test the key auth plugin
+
+stages:
+  - name: Create a service
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/services"
+      method: POST
+      json:
+        name: keyauthservice
+        url: http://mockbin.org
+    response:
+      status_code:
+        - 201
+      save:
+        body:
+          service_id: id
+    delay_after: 5
+    max_retries: 1
+  - name: Create a route
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/services/{service_id:s}/routes"
+      method: POST
+      json:
+        name: "keyauthroute"
+        hosts:
+        - "randomapiname.com"
+    response:
+      status_code:
+        - 201
+      save:
+        body:
+          route_id: id
+    delay_after: 5
+    max_retries: 1
+  - name: Enable the key-auth plugin
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/services/keyauthservice/plugins/"
+      method: POST
+      json:
+        name: key-auth
+    response:
+      strict: False
+      status_code: 201
+      save:
+        body:
+          plugin_id: id
+    delay_after: 5
+    max_retries: 1
+  - name: Proxy a request
+    request:
+      url: "{tavern.env_vars.PROXY_URI}/request"
+      method: GET
+      headers:
+        host: randomapiname.com
+    response:
+      strict: False
+      status_code: 401
+      body:
+        message: "No API key found in request"
+    delay_after: 5
+    max_retries: 1
+  - name: Create a consumer
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/consumers/"
+      method: POST
+      json:
+        username: Jason
+    response:
+      strict: False
+      status_code: 201
+      save:
+        body:
+          consumer_id: id
+    delay_after: 5
+    max_retries: 1
+  - name: Provision a key for the consumer
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/consumers/Jason/key-auth"
+      method: POST    
+      json:
+        key: "90210"
+    response:
+      strict: False
+      status_code: 201
+      save:
+        body:
+          key_id: id
+    delay_after: 5
+    max_retries: 1
+  - name: Proxy a request with the key provided
+    request:
+      url: "{tavern.env_vars.PROXY_URI}/request"
+      method: GET
+      headers:
+        host: randomapiname.com
+        apikey: "90210"
+    response:
+      strict: False
+      status_code: 200
+      body:
+        url: http://randomapiname.com/request
+      headers:
+        Via: "kong/{tavern.env_vars.KONG_VERSION}"
+  - name: Delete the key-auth key
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/consumers/Jason/key-auth/{key_id:s}"
+      method: DELETE
+    response:
+      status_code: 204
+  - name: Delete the consumer
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/consumers/Jason"
+      method: DELETE
+    response:
+      status_code: 204
+  - name: Delete the route
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/routes/keyauthroute"
+      method: DELETE
+    response:
+      status_code: 204
+  - name: Delete the service
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/services/keyauthservice"
+      method: DELETE
+    response:
+      status_code: 204

--- a/test/test_smoke.tavern.yaml
+++ b/test/test_smoke.tavern.yaml
@@ -17,7 +17,7 @@ stages:
       url: "{tavern.env_vars.ADMIN_URI}/services"
       method: POST
       json:
-        name: randomapiname
+        name: smoketestservice
         url: http://mockbin.org
     response:
       status_code:
@@ -43,6 +43,7 @@ stages:
       url: "{tavern.env_vars.ADMIN_URI}/routes"
       method: POST
       json:
+        name: smoketestroute
         service:
           id: "{service_id:s}"
         hosts:
@@ -80,5 +81,21 @@ stages:
         url: http://randomapiname.com/request
       headers:
         Via: "kong/{tavern.env_vars.KONG_VERSION}"
+    delay_after: 5
+    max_retries: 1
+  - name: Delete the route
+    request:
+      url: "{tavern.env_vars.ADMIN_URI}/routes/smoketestroute"
+      method: DELETE
+    response:
+      status_code: 204
+    delay_after: 5
+    max_retries: 1
+  - name: Delete the service
+    request:
+      url: "{tavern.env_vars.ADMIN_URI}/services/smoketestservice"
+      method: DELETE
+    response:
+      status_code: 204
     delay_after: 5
     max_retries: 1


### PR DESCRIPTION
- added a convenience method to make developing functional tests easier
- tweaked the smoke test to delete the service and route that it creates
- added a functional test for key-auth plugin functionality