### PR TITLE
fix(dependency) add libyaml dependency

### DIFF
--- a/Dockerfile.openresty
+++ b/Dockerfile.openresty
@@ -6,6 +6,7 @@ FROM kong:${RESTY_IMAGE_BASE}-${RESTY_IMAGE_TAG}
 ARG OPENSSL_EXTRA_OPTIONS
 ARG RESTY_VERSION=1.13.6.2
 ARG RESTY_LUAROCKS_VERSION=2.4.3
+ARG LIBYAML_VERSION=0.2.1
 ARG RESTY_OPENSSL_VERSION=1.1.1
 ARG RESTY_PCRE_VERSION=8.41
 ARG RESTY_J=2
@@ -42,13 +43,21 @@ RUN cd /tmp \
 
 ADD https://openresty.org/download/openresty-${RESTY_VERSION}.tar.gz /tmp/openresty-${RESTY_VERSION}.tar.gz
 ADD https://github.com/Kong/openresty-patches/archive/master.tar.gz /tmp/kong-patches.tar.gz
-
 ADD https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz /tmp/pcre-${RESTY_PCRE_VERSION}.tar.gz
 ADD https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz /tmp/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
+ADD https://pyyaml.org/download/libyaml/yaml-${LIBYAML_VERSION}.tar.gz /tmp/yaml-${LIBYAML_VERSION}.tar.gz
 
 RUN cd /tmp \
     && tar xzf pcre-${RESTY_PCRE_VERSION}.tar.gz \
-    && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz
+    && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
+    && tar xzf yaml-${LIBYAML_VERSION}.tar.gz
+
+RUN cd /tmp/yaml-${LIBYAML_VERSION} \
+    && ./configure \
+      --libdir=/tmp/build/usr/local/kong/lib \
+      --includedir=/tmp/yaml-${LIBYAML_VERSION} \
+    && make -j${RESTY_J} \
+    && make install
 
 RUN cd /tmp \
     && tar xzf openresty-${RESTY_VERSION}.tar.gz \

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_OPENSSL_VERSION ?= `grep RESTY_OPENSSL_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_PCRE_VERSION ?= `grep RESTY_PCRE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
+LIBYAML_VERSION ?= 0.2.1
+LYAML_VERSION ?= 6.2.3
 
 release-kong: test
 	RESTY_IMAGE_BASE=$(RESTY_IMAGE_BASE) \
@@ -75,6 +77,8 @@ build-kong: build-openresty-base
 	-e KONG_LICENSE=$(KONG_LICENSE) \
 	-e RESTY_IMAGE_TAG=$(RESTY_IMAGE_TAG) \
 	-e RESTY_IMAGE_BASE=$(RESTY_IMAGE_BASE) \
+	-e LIBYAML_VERSION=$(LIBYAML_VERSION) \
+	-e LYAML_VERSION=$(LYAML_VERSION) \
 	kong:kong-$(RESTY_IMAGE_BASE)-$(RESTY_IMAGE_TAG)
 
 build-openresty-base: build-base
@@ -86,6 +90,7 @@ build-openresty-base: build-base
 	--build-arg RESTY_IMAGE_TAG="$(RESTY_IMAGE_TAG)" \
 	--build-arg RESTY_IMAGE_BASE=$(RESTY_IMAGE_BASE) \
 	--build-arg OPENSSL_EXTRA_OPTIONS=$(OPENSSL_EXTRA_OPTIONS) \
+	--build-arg LIBYAML_VERSION=$(LIBYAML_VERSION) \
 	-t kong:openresty-$(RESTY_IMAGE_BASE)-$(RESTY_IMAGE_TAG) .
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,11 +17,20 @@ pushd /tmp/openssl
   make install_sw
 popd
 
+pushd /tmp/yaml-${LIBYAML_VERSION}
+  make install
+popd
+
 pushd /kong
-  ROCKSPEC_VERSION=`basename $TMP/kong/kong-*.rockspec` \
+  ROCKSPEC_VERSION=`basename /kong/kong-*.rockspec` \
     && ROCKSPEC_VERSION=${ROCKSPEC_VERSION%.*} \
     && ROCKSPEC_VERSION=${ROCKSPEC_VERSION#"kong-"}
-    
+
+  /tmp/build/usr/local/bin/luarocks install lyaml $LYAML_VERSION \
+    YAML_LIBDIR=/tmp/build/usr/local/kong/lib \
+    YAML_INCDIR=/tmp/yaml-${LIBYAML_VERSION} \
+    CFLAGS="-L/tmp/build/usr/local/kong/lib -Wl,-rpath,/usr/local/kong/lib -O2 -fPIC"
+
   /tmp/build/usr/local/bin/luarocks make kong-${ROCKSPEC_VERSION}.rockspec \
     OPENSSL_LIBDIR=/tmp/openssl \
     OPENSSL_DIR=/tmp/openssl


### PR DESCRIPTION
Kong 1.1.0 is going to require libyaml to be installed

All four `next` builds fail
![capture](https://user-images.githubusercontent.com/697188/53120988-1f7d2980-3521-11e9-8444-0a6d71e01933.PNG)

Now they pass
![capture2](https://user-images.githubusercontent.com/697188/53120993-2310b080-3521-11e9-85bc-5737d514b21d.PNG)

Needed to fix daily builds of [next](https://travis-ci.org/Kong/kong/builds/496104400)
