### PR TITLE
test(request termination)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ The Kong functional tests use (Tavern)[https://taverntesting.github.io/].
 *Prerequisites*
 
 - Docker
+- A Packaged Kong Release (`make package-kong`)
+- K8s and helm (`make setup-tests`)
 
 ```
-make run_tests
+make test
 ```
 
 Will run the functional tests against the defaults specified in the Makefile prefixed with `TEST_`
@@ -90,6 +92,16 @@ TEST_ADMIN_URI?=$(TEST_ADMIN_PROTOCOL)$(TEST_HOST):$(TEST_ADMIN_PORT)
 TEST_PROXY_PROTOCOL?=http://
 TEST_PROXY_PORT?=8000
 TEST_PROXY_URI?=$(TEST_PROXY_PROTOCOL)$(TEST_HOST):$(TEST_PROXY_PORT)
+```
+
+### Developing Functional Tests
+
+With the same prerequisites as running functional tests
+
+```
+make test
+make develop_tests
+py.test test_your_test.tavern.yaml # Expect warnings about https and structure different
 ```
 
 ## Releasing a Kong Distribution

--- a/test/test_plugin-request-termination.tavern.yaml
+++ b/test/test_plugin-request-termination.tavern.yaml
@@ -1,0 +1,59 @@
+---
+test_name: Test the request termination plugin
+
+stages:
+  - name: Create a route
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/routes"
+      method: POST
+      json:
+        name: "requestterminationroute"
+        hosts:
+        - "requestterminationroute.com"
+    response:
+      status_code:
+        - 201
+      save:
+        body:
+          route_id: id
+    delay_after: 5
+    max_retries: 1
+  - name: Enable the request termination plugin
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/routes/requestterminationroute/plugins/"
+      method: POST
+      json:
+        name: request-termination
+        config:
+          status_code: 418
+          message: "Im a teapot"
+    response:
+      strict: False
+      status_code: 201
+      save:
+        body:
+          plugin_id: id
+    delay_after: 5
+    max_retries: 1
+  - name: Use the request termination plugin
+    request:
+      url: "{tavern.env_vars.PROXY_URI}/request"
+      method: GET
+      headers:
+        host: requestterminationroute.com
+    response:
+      strict: False
+      status_code: 418
+      body:
+        message: "Im a teapot"
+    delay_after: 5
+    max_retries: 1
+  - name: Delete the route
+    request:
+      verify: false
+      url: "{tavern.env_vars.ADMIN_URI}/routes/requestterminationroute"
+      method: DELETE
+    response:
+      status_code: 204


### PR DESCRIPTION
Test serviceless route that is using the request termination plugin.

This PR / branch will *not* pass until https://github.com/Kong/kong/pull/4286 is merged