### PR TITLE
fix(luarocks) adjust for luarocks directory name change

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ pushd /kong
     OPENSSL_DIR=/tmp/openssl
 
   mkdir -p /tmp/build/etc/kong
-  cp kong.conf.default /tmp/build/usr/local/lib/luarocks/rocks/kong/$ROCKSPEC_VERSION/kong.conf.default
+  cp kong.conf.default /tmp/build/usr/local/lib/luarocks/rock*/kong/$ROCKSPEC_VERSION/
   cp kong.conf.default /tmp/build/etc/kong/kong.conf.default
 popd
 


### PR DESCRIPTION
A directory name changed from / to
```
/usr/local/lib/luarocks/rocks/kong/
```
```
/usr/local/lib/luarocks/rocks-5.1/kong/
```

This handles the change while keeping backwards compatibility