### PR TITLE
fix(luarocks) fix for luarocks 3.1.2 compilation issue

### DIFF
--- a/Dockerfile.kong
+++ b/Dockerfile.kong
@@ -90,14 +90,15 @@ RUN curl -fsSLo /tmp/pcre-${RESTY_PCRE_VERSION}.tar.gz https://ftp.pcre.org/pub/
 ARG RESTY_LUAROCKS_VERSION=2.4.3
 LABEL resty_luarocks_version="${RESTY_LUAROCKS_VERSION}"
 RUN curl -fsSLo /tmp/luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz https://github.com/luarocks/luarocks/archive/${RESTY_LUAROCKS_VERSION}.tar.gz \
+    && cp -R /tmp/build/* / \
     && cd /tmp \
     && tar xzf luarocks-${RESTY_LUAROCKS_VERSION}.tar.gz \
     && ln -s /tmp/luarocks-${RESTY_LUAROCKS_VERSION} /tmp/luarocks \
     && cd /tmp/luarocks \
     && eval ./configure \
         --lua-suffix=jit \
-        --with-lua=/tmp/build/usr/local/openresty/luajit \
-        --with-lua-include=/tmp/build/usr/local/openresty/luajit/include/luajit-2.1 \
+        --with-lua=/usr/local/openresty/luajit \
+        --with-lua-include=/usr/local/openresty/luajit/include/luajit-2.1 \
     && make build \
     && make install DESTDIR=/tmp/build
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ pushd /kong
     OPENSSL_DIR=/tmp/openssl
 
   mkdir -p /tmp/build/etc/kong
-  cp kong.conf.default /tmp/build/usr/local/lib/luarocks/rocks/kong/$ROCKSPEC_VERSION/kong.conf.default
+  cp kong.conf.default /tmp/build/usr/local/lib/luarocks/rock*/kong/$ROCKSPEC_VERSION/
   cp kong.conf.default /tmp/build/etc/kong/kong.conf.default
 popd
 


### PR DESCRIPTION
when building packages we configure and install to a temporary directory for the purposes of packaging ( `/tmp/build` ) but when the resulting package is installed on host systems it installs to `/`

This fix is specific to luarocks `3.1.2` which when installed with lua in `/tmp/build` will hold onto that piece of information even after being installed on a host system. Quickfix for this is to configure luarocks with the correct final location of lua by temporarily `cp -R /tmp/build/* /`