### PR TITLE
test(k8s-sidecar) make test setup more flexible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,11 +206,11 @@ cleanup_tests:
 
 setup_tests: cleanup_tests
 ifeq (, $(shell which minikube))
-	curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+	curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.33.1/minikube-linux-amd64
 	sudo cp minikube /usr/local/bin/
 	sudo chmod 755 /usr/local/bin/minikube
 	rm minikube
-	curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+	curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.12.8/bin/linux/amd64/kubectl
 	sudo cp kubectl /usr/local/bin/
 	sudo chmod 755 /usr/local/bin/kubectl
 	rm kubectl
@@ -220,7 +220,7 @@ ifeq (, $(shell which minikube))
 	rm -rf get_helm.sh
 	sudo apt-get update && sudo apt-get install -y socat
 endif
-	sudo minikube start --vm-driver none
+	sudo minikube start --vm-driver none --kubernetes-version=v1.13.2
 	sudo minikube addons enable registry
 	sudo chown -R $$USER $$HOME/.minikube
 	sudo chgrp -R $$USER $$HOME/.minikube

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ KONG_CONFLICTS?="kong-enterprise-edition"
 KONG_LICENSE?="ASL 2.0"
 
 PRIVATE_REPOSITORY?=true
-KONG_TEST_CONTAINER_NAME?=localhost:5000/kong-$(RESTY_IMAGE_BASE)-$(RESTY_IMAGE_TAG)
+KONG_TEST_CONTAINER_TAG?=5000/kong-$(RESTY_IMAGE_BASE)-$(RESTY_IMAGE_TAG)
+KONG_TEST_CONTAINER_NAME?=localhost:$(KONG_TEST_CONTAINER_TAG)
 KONG_VERSION?=`echo $(KONG_SOURCE_LOCATION)/kong-*.rockspec | sed 's,.*/,,' | cut -d- -f2`
 RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
@@ -176,6 +177,8 @@ test: build_test_container
 	RESTY_IMAGE_BASE=$(RESTY_IMAGE_BASE) \
 	RESTY_IMAGE_TAG=$(RESTY_IMAGE_TAG) \
 	KONG_PACKAGE_NAME=$(KONG_PACKAGE_NAME) \
+	KONG_TEST_CONTAINER_TAG=$(KONG_TEST_CONTAINER_TAG) \
+	KONG_TEST_CONTAINER_NAME=$(KONG_TEST_CONTAINER_NAME) \
 	./test/run_tests.sh
 
 run_tests:
@@ -188,7 +191,7 @@ develop_tests:
 	-e ADMIN_URI="https://`kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}'`:`kubectl get svc --namespace default kong-kong-admin -o jsonpath='{.spec.ports[0].nodePort}'`" \
 	-e PROXY_URI="http://`kubectl get nodes --namespace default -o jsonpath='{.items[0].status.addresses[0].address}'`:`kubectl get svc --namespace default kong-kong-proxy -o jsonpath='{.spec.ports[0].nodePort}'`" \
 	-v $$PWD/test:/app \
-	kong:test_runner /bin/bash
+	kong/kong-build-tools:test_runner /bin/bash
 
 build_test_container:
 	RESTY_IMAGE_BASE=$(RESTY_IMAGE_BASE) \

--- a/test/build_container.sh
+++ b/test/build_container.sh
@@ -1,3 +1,4 @@
+if docker image inspect $KONG_TEST_CONTAINER_NAME; then exit 0; fi
 RHEL=false
 if [ "$RESTY_IMAGE_BASE" == "alpine" ]; then
   DOCKER_FILE="Dockerfile.alpine"

--- a/test/test_plugin-key-auth.tavern.yaml
+++ b/test/test_plugin-key-auth.tavern.yaml
@@ -107,6 +107,8 @@ stages:
         url: http://randomapiname.com/request
       headers:
         Via: "kong/{tavern.env_vars.KONG_VERSION}"
+    delay_after: 5
+    max_retries: 1
   - name: Delete the key-auth key
     request:
       verify: false
@@ -114,6 +116,8 @@ stages:
       method: DELETE
     response:
       status_code: 204
+    delay_after: 5
+    max_retries: 1
   - name: Delete the consumer
     request:
       verify: false
@@ -121,6 +125,8 @@ stages:
       method: DELETE
     response:
       status_code: 204
+    delay_after: 5
+    max_retries: 1
   - name: Delete the route
     request:
       verify: false
@@ -128,6 +134,8 @@ stages:
       method: DELETE
     response:
       status_code: 204
+    delay_after: 5
+    max_retries: 1
   - name: Delete the service
     request:
       verify: false
@@ -135,3 +143,5 @@ stages:
       method: DELETE
     response:
       status_code: 204
+    delay_after: 5
+    max_retries: 1


### PR DESCRIPTION
This is needed so we can test custom Kong images. Plugins can build a custom tagged docker image and utilize kong build tools to functionally test said plugin