### PR TITLE
fix(ci) make sure we wait until k8s is ready before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ before_script:
 script:
   - cat setup.log
   - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-  - until kubectl get nodes | grep -q Ready; do sleep 5 && kubectl get nodes; done
   - make test
 
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -201,3 +201,5 @@ build_test_container:
 	KONG_TEST_CONTAINER_NAME=$(KONG_TEST_CONTAINER_NAME) \
 	test/build_container.sh
 
+setup_tests:
+	./.ci/setup_ci.sh

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -25,6 +25,8 @@ helm install --dep-up --version 0.10.1 --name kong --set image.repository=localh
 while [[ "$(kubectl get deployment kong-kong | tail -n +2 | awk '{print $4}')" != 1 ]]; do
   echo "waiting for Kong to be ready"
   kubectl get deployment kong-kong
+  kubectl get all
+  docker ps -a
   sleep 10;
 done
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -32,7 +32,8 @@ helm install --dep-up --version 0.10.1 --name kong --set image.repository=localh
 while [[ "$(kubectl get deployment kong-kong | tail -n +2 | awk '{print $4}')" != 1 ]]; do
   echo "waiting for Kong to be ready"
   kubectl get pod --all-namespaces -o wide
-  docker ps -a
+  kubectl describe pod/kong-postgresql-0
+  kubectl logs pod/kong-postgresql-0 || true
   sleep 10;
 done
 


### PR DESCRIPTION
recreate the `make setup_tests` for backwards compatibility until we can migrate everything away from it.

make sure the kind k8s cluster is entirely ready before trying to begin the functional tests