### PR TITLE
fix(helm) adjust how we pin the helm version

### DIFF
--- a/.ci/setup_kind.sh
+++ b/.ci/setup_kind.sh
@@ -16,9 +16,9 @@ fi
 K8S_VERSION="${K8S_VERSION:-v1.15.0}"
 kind create cluster --image "kindest/node:${K8S_VERSION}"
 if ! [ -x "$(command -v helm)" ]; then
-    curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/v2.15.0/scripts/get
+    curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get
     chmod +x get_helm.sh
-    sudo ./get_helm.sh
+    sudo DESIRED_VERSION=v2.16.1 ./get_helm.sh
     rm -rf get_helm.sh
 fi
 export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"

--- a/.ci/setup_kind.sh
+++ b/.ci/setup_kind.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 if ! [ -x "$(command -v kind)" ]; then
-    curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.4.0/kind-linux-amd64
+    curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/v0.5.1/kind-linux-amd64
     chmod +x ./kind
     mv kind $HOME/bin/
 fi
@@ -13,7 +13,7 @@ if ! [ -x "$(command -v kubectl)" ]; then
     chmod +x ./kubectl
     mv kubectl $HOME/bin/
 fi
-K8S_VERSION="${K8S_VERSION:-v1.15.0}"
+K8S_VERSION="${K8S_VERSION:-v1.16.2}"
 kind create cluster --image "kindest/node:${K8S_VERSION}"
 if ! [ -x "$(command -v helm)" ]; then
     curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get


### PR DESCRIPTION
The v2.15.0 get_helm script doesn't know not to accidentally pull helm 3.0. Use `master` of `get_helm.sh` and use an environment variable to pin helm version