### PR TITLE
feat(sign) setup rpm signing

### DIFF
--- a/.rpmmacros
+++ b/.rpmmacros
@@ -1,0 +1,2 @@
+%_signature gpg
+%_gpg_name Kong Inc <kong@konghq.com>

--- a/Dockerfile.package
+++ b/Dockerfile.package
@@ -9,6 +9,11 @@ FROM kong/fpm:0.0.1 as FPM
 
 COPY --from=KONG /tmp/build /tmp/build
 COPY fpm-entrypoint.sh /fpm-entrypoint.sh
+COPY .rpmmacros /root/.rpmmacros
+ARG PRIVATE_KEY_FILE
+COPY ${PRIVATE_KEY_FILE} /kong.private.asc 
+ARG PRIVATE_KEY_PASSPHRASE
+ENV PRIVATE_KEY_PASSPHRASE ${PRIVATE_KEY_PASSPHRASE}
 
 ARG RESTY_IMAGE_BASE="ubuntu"
 ARG RESTY_IMAGE_TAG="xenial"

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ package-kong: actual-package-kong
 endif
 
 actual-package-kong: build-kong
-	$(DOCKER_COMMAND) -f Dockerfile.package \
+	@$(DOCKER_COMMAND) -f Dockerfile.package \
 	--build-arg RESTY_IMAGE_TAG="$(RESTY_IMAGE_TAG)" \
 	--build-arg RESTY_IMAGE_BASE=$(RESTY_IMAGE_BASE) \
 	--build-arg DOCKER_KONG_SUFFIX=$(DOCKER_KONG_SUFFIX) \
@@ -213,6 +213,8 @@ actual-package-kong: build-kong
 	--build-arg KONG_VERSION=$(KONG_VERSION) \
 	--build-arg KONG_PACKAGE_NAME=$(KONG_PACKAGE_NAME) \
 	--build-arg KONG_CONFLICTS=$(KONG_CONFLICTS) \
+	--build-arg PRIVATE_KEY_FILE=kong.private.gpg-key.asc \
+	--build-arg PRIVATE_KEY_PASSPHRASE="$(PRIVATE_KEY_PASSPHRASE)" \
 	-t kong/kong-build-tools:kong-packaged-$(RESTY_IMAGE_BASE)-$(RESTY_IMAGE_TAG)-$(DOCKER_KONG_SUFFIX) .
 ifeq ($(BUILDX),false)
 	docker run -d --rm --name output kong/kong-build-tools:kong-packaged-$(RESTY_IMAGE_BASE)-$(RESTY_IMAGE_TAG)-$(DOCKER_KONG_SUFFIX) tail -f /dev/null

--- a/fpm-entrypoint.sh
+++ b/fpm-entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-set -e
-set -x
+set -o errexit
 
 cd /tmp/build
 
@@ -50,5 +49,9 @@ else
     --url 'https://getkong.org/' usr etc \
   && mkdir /output/ \
   && mv kong*.* /output/${KONG_PACKAGE_NAME}-${KONG_VERSION}${OUTPUT_FILE_SUFFIX}.${PACKAGE_TYPE}
+  if [ "$PACKAGE_TYPE" == "rpm" ] && [ ! -z "$PRIVATE_KEY_PASSPHRASE" ]; then
+    gpg --import /kong.private.asc
+    echo "$PRIVATE_KEY_PASSPHRASE" | rpm --addsign /output/${KONG_PACKAGE_NAME}-${KONG_VERSION}${OUTPUT_FILE_SUFFIX}.${PACKAGE_TYPE} > /dev/null 2>&1
+  fi
 fi
 


### PR DESCRIPTION
To create signed rpm releases:
- replace kong.private.gpg-key.asc with a actual private key
- export PRIVATE_KEY_PASSPHRASE

Default behaviour if PRIVATE_KEY_PASSPHRASE isn't set we create a normal rpm package

```
make package-kong
rpm -K output/kong-1.4.0.el8.amd64.rpm
output/kong-1.4.0.el8.amd64.rpm: RSA sha1 ((MD5) PGP) md5 NOT OK (MISSING KEYS: (MD5) PGP#1d5f3726)

unset PRIVATE_KEY_PASSPHRASE
make package-kong
rpm -K output/kong-1.4.0.el8.amd64.rpm
output/kong-1.4.0.el8.amd64.rpm: sha1 md5 OK
```