### PR TITLE
feat(rhel6) drop redhat 6 as a build option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
     - PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=centos RESTY_IMAGE_TAG=6 KONG_SOURCE=master
     - PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=rhel RESTY_IMAGE_TAG=8 KONG_SOURCE=master
     - PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=rhel RESTY_IMAGE_TAG=7 KONG_SOURCE=master
-    - PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=rhel RESTY_IMAGE_TAG=6 KONG_SOURCE=master
     - PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=xenial KONG_SOURCE=master CACHE=false UPDATE_CACHE=true
     - PACKAGE_TYPE=deb RESTY_IMAGE_BASE=ubuntu RESTY_IMAGE_TAG=bionic KONG_SOURCE=master
     - PACKAGE_TYPE=deb RESTY_IMAGE_BASE=debian RESTY_IMAGE_TAG=stretch KONG_SOURCE=master
@@ -45,5 +44,5 @@ script:
   - make test
 
 after_script:
-  - make cleanup_build
+  - make cleanup-build
 

--- a/test/Dockerfile.rpm
+++ b/test/Dockerfile.rpm
@@ -14,15 +14,9 @@ ARG REDHAT_USERNAME
 ARG REDHAT_PASSWORD
 ARG RHEL="false"
 
-RUN if [ "$RHEL" = "true" ] ; then subscription-manager register --username ${REDHAT_USERNAME} --password ${REDHAT_PASSWORD} --auto-attach ; fi
+RUN if [ "$RHEL" = "true" ] ; then yum -y install --disableplugin=subscription-manager perl perl-Time-HiRes gcc make unzip tar gzip shadow-utils hostname unzip ; fi
 
-RUN yum -y install perl perl-Time-HiRes gcc make unzip tar gzip shadow-utils hostname unzip
-
-RUN if [ "$RHEL" = "true" ] ; then \
-  subscription-manager remove --all \
-  && subscription-manager unregister \
-  && subscription-manager clean \
-  ; fi
+RUN if [ "$RHEL" = "false" ] ; then yum -y install perl perl-Time-HiRes gcc make unzip tar gzip shadow-utils hostname unzip ; fi
 
 RUN curl -sL "${SU_EXEC_URL}" | tar -C /tmp -zxf - \
   && make -C "/tmp/su-exec-${SU_EXEC_VERSION}" \


### PR DESCRIPTION
RHEL6 full support ended on May 10, 2016, End of Maintenance Support 1 ended on May 10, 2017.

The RHEL 7 and RHEL 8 ubi images have the ability to install and test our Kong releases without requiring redhat credentials.

These two reasons are strong enough reasons that it's time to ditch rhel6