### PR TITLE
chore(ci) adjust arm build workers to include a random element to the machine name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,14 +96,13 @@ pipeline {
                         USER = 'travis'
                         AWS_ACCESS_KEY = credentials('AWS_ACCESS_KEY')
                         AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
-                        DOCKER_MACHINE_ARM64_NAME = "jenkins-kong-${env.BUILD_NUMBER}"
                     }
                     steps {
                         sh 'mkdir -p /home/ubuntu/bin/'
                         sh 'make setup-ci'
                         sh 'git clone --single-branch --branch ${KONG_SOURCE} https://github.com/Kong/kong.git ${KONG_SOURCE_LOCATION}'
                         sh 'export BUILDX=false RESTY_IMAGE_TAG=bionic && make package-kong && make test'
-                        sh 'export CACHE=false UPDATE_CACHE=true RESTY_IMAGE_TAG=xenial && make setup-build && make package-kong && make test'
+                        sh 'export CACHE=false UPDATE_CACHE=true RESTY_IMAGE_TAG=xenial DOCKER_MACHINE_ARM64_NAME="jenkins-kong-"`cat /proc/sys/kernel/random/uuid` && make setup-build && make package-kong && make test'
                     }
                 }
             }


### PR DESCRIPTION
ec2 workers for building arm assets require a random element to their name. We were hitting an issue with branch and PR builds or kong-build-tools trying to make ec2 machines with the same name and one of the two will fail.