### PR TITLE
fix(base) add missing go-pluginserver build arg

### DIFF
--- a/Dockerfile.openresty
+++ b/Dockerfile.openresty
@@ -69,7 +69,9 @@ RUN set -eux; \
 	export PATH="/usr/local/go/bin:$PATH"; \
 	go version 
 
-ENV KONG_GO_PLUGINSERVER_VERSION=master
+ARG KONG_GO_PLUGINSERVER_VERSION=master
+ENV KONG_GO_PLUGINSERVER_VERSION $KONG_GO_PLUGINSERVER_VERSION
+
 ENV GOPATH=/tmp/go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 


### PR DESCRIPTION
edit: failing because Kong/kong master does not have the pluginserver version in its .requirements file.