### PR TITLE
fix(rpm) fix rpm builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent none
     environment {
-        KONG_SOURCE = "release/2.0.0"
+        KONG_SOURCE = "next"
         KONG_SOURCE_LOCATION = "/tmp/kong"
         DOCKER_USERNAME = "${env.DOCKERHUB_USR}"
         DOCKER_PASSWORD = "${env.DOCKERHUB_PSW}"

--- a/dockerfiles/Dockerfile.rpm
+++ b/dockerfiles/Dockerfile.rpm
@@ -6,8 +6,5 @@ ARG RESTY_IMAGE_TAG="7"
 
 FROM ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}
 
-RUN sed -i -e '2 i minrate=1' /etc/yum.conf
-RUN yum clean all && yum update -y
-
 RUN yum -y install wget tar readline-devel pcre-devel openssl-devel gcc curl unzip \
   zlib-devel make gcc gcc-c++ bzip2 patch perl m4 git


### PR DESCRIPTION
Centos and RHEL 8 builds started to fail with the following:
```
error: rpmdb: BDB0060 PANIC: fatal region error detected; run recovery
error: db5 error(-30973) from db->close: BDB0087 DB_RUNRECOVERY: Fatal error, run database recovery
```

![image](https://user-images.githubusercontent.com/697188/74172969-32d84780-4bff-11ea-8529-54ac678d7206.png)
