### PR TITLE
Fix kong-ngx-build bugs

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -188,7 +188,7 @@ main() {
       if [ ! -z ${OPENSSL_SHA+x} ]; then
         echo "$OPENSSL_SHA openssl-$OPENSSL_VER.tar.gz" | sha256sum -c -
       fi
-      tar -xzvf openssl-$OPENSSL_VER.tar.gz
+      tar -xzf openssl-$OPENSSL_VER.tar.gz
     fi
 
     # OpenResty
@@ -209,7 +209,7 @@ main() {
         if [ ! -z ${OPENRESTY_SHA+x} ]; then
           echo "$OPENRESTY_SHA openresty-$OPENRESTY_VER.tar.gz" | sha256sum -c -
         fi
-        tar -xzvf openresty-$OPENRESTY_VER.tar.gz
+        tar -xzf openresty-$OPENRESTY_VER.tar.gz
       fi
     fi
 
@@ -223,7 +223,7 @@ main() {
         if [ ! -z ${PCRE_SHA+x} ]; then
           echo "$PCRE_SHA pcre-${PCRE_VER}.tar.gz" | sha256sum -c -
         fi
-        tar -xzvf pcre-${PCRE_VER}.tar.gz
+        tar -xzf pcre-${PCRE_VER}.tar.gz
       fi
     fi
 
@@ -241,7 +241,7 @@ main() {
           if [ ! -z ${LUAROCKS_SHA+x} ]; then
             echo "$LUAROCKS_SHA luarocks-$LUAROCKS_VER.tar.gz" | sha256sum -c -
           fi
-          tar -xzvf luarocks-$LUAROCKS_VER.tar.gz
+          tar -xzf luarocks-$LUAROCKS_VER.tar.gz
         fi
       fi
     fi

--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -424,12 +424,14 @@ main() {
           "--with-http_v2_module"
           "-j$NPROC"
         )
-        
+
         if [ $EDITION == 'enterprise' ]; then
-            OPENRESTY_OPTS+=('--add-module=/enterprise/kong-licensing/ngx_module')
-            OPENRESTY_OPTS+=('--add-module=/enterprise/lua-kong-nginx-module')
+          OPENRESTY_OPTS+=('--add-module=/enterprise/kong-licensing/ngx_module')
+          OPENRESTY_OPTS+=('--add-module=/enterprise/lua-kong-nginx-module')
+
         elif [ $KONG_NGINX_MODULE != 0 ]; then
           OPENRESTY_OPTS+=('--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module')
+          OPENRESTY_OPTS+=('--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module/stream')
         fi
 
         if version_gte $NGINX_CORE_VER 1.11.4; then


### PR DESCRIPTION
Stream lua-kong-nginx-module is no longer being built, causing Travis tests to fail unexpectedly.