### PR TITLE
fix(kong-ngx-build) mac fixes

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -425,7 +425,7 @@ main() {
           "-j$NPROC"
         )
 
-        if [ $EDITION == 'enterprise' ]; then
+        if [ "$EDITION" == 'enterprise' ]; then
           OPENRESTY_OPTS+=('--add-module=/enterprise/kong-licensing/ngx_module')
           OPENRESTY_OPTS+=('--add-module=/enterprise/lua-kong-nginx-module')
 

--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -430,8 +430,8 @@ main() {
           OPENRESTY_OPTS+=('--add-module=/enterprise/lua-kong-nginx-module')
 
         elif [ $KONG_NGINX_MODULE != 0 ]; then
-          OPENRESTY_OPTS+=('--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module')
-          OPENRESTY_OPTS+=('--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module/stream')
+          OPENRESTY_OPTS+=("--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module")
+          OPENRESTY_OPTS+=("--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module/stream")
         fi
 
         if version_gte $NGINX_CORE_VER 1.11.4; then
@@ -443,7 +443,7 @@ main() {
         fi
 
         if [ ! -z "$PCRE_VER" ]; then
-          OPENRESTY_OPTS+=('--with-pcre=$PCRE_DOWNLOAD')
+          OPENRESTY_OPTS+=("--with-pcre=$PCRE_DOWNLOAD")
 
         else
           OPENRESTY_OPTS+=('--with-pcre')

--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -416,7 +416,6 @@ main() {
         OPENRESTY_OPTS=(
           "--prefix=$OPENRESTY_PREFIX"
           "--with-cc-opt='-I$OPENSSL_INSTALL/include'"
-          "--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,--disable-new-dtags,-rpath,$OPENRESTY_RPATH'"
           "--with-pcre-jit"
           "--with-http_ssl_module"
           "--with-http_realip_module"
@@ -432,6 +431,12 @@ main() {
         elif [ $KONG_NGINX_MODULE != 0 ]; then
           OPENRESTY_OPTS+=("--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module")
           OPENRESTY_OPTS+=("--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module/stream")
+        fi
+
+        if ld --disable-new-dtags 2>&1 >/dev/null | grep -q "disable-new-dtags"; then
+          OPENRESTY_OPTS+=("--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENRESTY_RPATH'")
+        else
+          OPENRESTY_OPTS+=("--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,--disable-new-dtags,-rpath,$OPENRESTY_RPATH'")
         fi
 
         if version_gte $NGINX_CORE_VER 1.11.4; then


### PR DESCRIPTION
This PR contains fixes for 2 errors and 1 warning detected while trying to make kong-ngx-build runable from homebrew.

Strongly recommended to do another patch tag (3.1.3?) of kong-build-tools after merging.