### PR TITLE
fix(build) support tags for kong-ngx-module

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -248,6 +248,9 @@ main() {
 
     # lua-kong-nginx-module
     if [ $KONG_NGINX_MODULE != 0 ]; then
+      if [[ $KONG_NGINX_MODULE == "master" ]]; then
+        KONG_NGINX_MODULE="origin/master"
+      fi
       pushd $DOWNLOAD_CACHE
         if [ ! -d lua-kong-nginx-module ]; then
           warn "lua-kong-nginx-module source not found, cloning..."
@@ -256,7 +259,8 @@ main() {
 
         pushd lua-kong-nginx-module
           git fetch
-          git reset --hard origin/$KONG_NGINX_MODULE
+          # Accept both tags, branches and SHAs
+          git reset --hard $KONG_NGINX_MODULE || git reset --hard origin/$KONG_NGINX_MODULE
         popd
       popd
     fi

--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -430,11 +430,13 @@ main() {
 
         if [ "$EDITION" == 'enterprise' ]; then
           OPENRESTY_OPTS+=('--add-module=/enterprise/kong-licensing/ngx_module')
-          OPENRESTY_OPTS+=('--add-module=/enterprise/lua-kong-nginx-module')
+        fi
 
-        elif [ $KONG_NGINX_MODULE != 0 ]; then
+        if [ $KONG_NGINX_MODULE != 0 ]; then
           OPENRESTY_OPTS+=("--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module")
-          OPENRESTY_OPTS+=("--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module/stream")
+          if [[ -d $DOWNLOAD_CACHE/lua-kong-nginx-module/stream ]]; then
+            OPENRESTY_OPTS+=("--add-module=$DOWNLOAD_CACHE/lua-kong-nginx-module/stream")
+          fi
         fi
 
         if ld --disable-new-dtags 2>&1 >/dev/null | grep -q "disable-new-dtags"; then


### PR DESCRIPTION
So far it only supports either `master` or a branch. We need to be able to pin either versions or SHAs directly, if we want to pin this repo at all, which I think we do, since `master` won't work with all versions always

* Allow tags and SHAs for kong-ngx-module version
* Only include `/stream` if it is in there.