### PR TITLE
fix(or-build-tools) fix openssl download 404

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -184,7 +184,14 @@ main() {
 
     if [[ ! -f $OPENSSL_INSTALL/bin/openssl && ! -d $OPENSSL_DOWNLOAD ]]; then
       warn "OpenSSL source not found, downloading..."
-      curl -sSLO https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz
+      set +e
+      curl --fail -sSLO https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz
+      if [[ $? != 0 ]]; then
+        curl --fail -sSLO https://www.openssl.org/source/old/${OPENSSL_VER//[a-z]/}/openssl-$OPENSSL_VER.tar.gz
+        [[ $? != 0 ]] && err "Could not download OpenSSL"
+      fi
+      set -e
+
       if [ ! -z ${OPENSSL_SHA+x} ]; then
         echo "$OPENSSL_SHA openssl-$OPENSSL_VER.tar.gz" | sha256sum -c -
       fi


### PR DESCRIPTION
Quickfix for openssl moving releases around. The pattern substitution is not perfect, but works for now. A better regex could work, but would also fail in some cases, ie: `0.9.x`.

The other option is to get the release directly from github: https://github.com/openssl/openssl/releases . We would need then to translate `1.1.1c` -> `OpenSSL_1_1_1c`