### PR TITLE
fixes leading whitespaces in wc command on osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,7 @@ endif
 
 test-kong: kong-test-container
 	docker-compose up -d
-	bash -c 'while [[ "$$(docker-compose ps | grep healthy | wc -l)" != "3" ]]; do docker-compose ps && sleep 5; done'
+	bash -c 'healthy=$$(docker-compose ps | grep healthy | wc -l); while [[ "$$(( $$healthy ))" != "3" ]]; do docker-compose ps && sleep 5; done'
 	docker exec kong /kong/.ci/run_tests.sh && make update-cache-images
 
 release-kong: test


### PR DESCRIPTION
The output of `wc -l` on mac osx has leading whitespaces, and hence this command hangs even when all 3 containers are `healthy`. This PR trims leading/trailing whitespaces.