### PR TITLE
test(systemd) add some verbosity to the systemd tests so we know why it fails

### DIFF
--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -35,11 +35,16 @@ EOD"
   sleep 5
   docker exec ${USE_TTY} systemd-ubuntu /bin/bash -c "systemctl start kong"
   sleep 5
+  docker exec ${USE_TTY} systemd-ubuntu /bin/bash -c "systemctl status kong"
   docker exec ${USE_TTY} systemd-ubuntu /bin/bash -c "systemctl reload kong"
   sleep 5
+  docker exec ${USE_TTY} systemd-ubuntu /bin/bash -c "systemctl status kong"
   docker exec ${USE_TTY} systemd-ubuntu /bin/bash -c "systemctl restart kong"
   sleep 5
+  docker exec ${USE_TTY} systemd-ubuntu /bin/bash -c "systemctl status kong"
   docker exec ${USE_TTY} systemd-ubuntu /bin/bash -c "systemctl stop kong"
+  sleep 5
+  docker exec ${USE_TTY} systemd-ubuntu /bin/bash -c "systemctl status kong"
   docker exec ${USE_TTY} systemd-ubuntu /bin/bash -c "dpkg --remove $KONG_PACKAGE_NAME"
   docker exec ${USE_TTY} systemd-ubuntu /bin/bash -c "! test -f /lib/systemd/system/kong.service"
   docker stop systemd-ubuntu


### PR DESCRIPTION
Add a `systectl status kong` so when kong fails on the systemctl test we know why without reproducing it locally

![image](https://user-images.githubusercontent.com/697188/84071359-8d11cb00-a99b-11ea-940f-2298185b20b7.png)
