### PR TITLE
fix(openresty-patches) add missing patch for FFI-based ngx.crc32 API

### DIFF
--- a/openresty-patches/patches/1.15.8.3/lua-resty-core-0.1.17_04-hash_stream_subsystem.patch
+++ b/openresty-patches/patches/1.15.8.3/lua-resty-core-0.1.17_04-hash_stream_subsystem.patch
@@ -1,0 +1,126 @@
+From cdb96165ac3cb2ca1202a6be1a28d297aadb4d12 Mon Sep 17 00:00:00 2001
+From: Thibault Charbonnier <thibaultcha@me.com>
+Date: Tue, 27 Aug 2019 10:44:54 -0700
+Subject: [PATCH] feature: enabled the FFI-based APIs for 'ngx.md5',
+ 'ngx.md5_bin', and 'ngx.sha1_bin' in the stream subsystem.
+
+---
+ lib/resty/core.lua      |  2 +-
+ lib/resty/core/hash.lua | 50 ++++++++++++++++++++++++++++++++---------
+ 2 files changed, 41 insertions(+), 11 deletions(-)
+
+diff --git a/lua-resty-core-0.1.17/lib/resty/core.lua b/lua-resty-core-0.1.17/lib/resty/core.lua
+index 57c9d17..4d2249f 100644
+--- a/lua-resty-core-0.1.17/lib/resty/core.lua
++++ b/lua-resty-core-0.1.17/lib/resty/core.lua
+@@ -7,11 +7,11 @@ require "resty.core.regex"
+ require "resty.core.shdict"
+ require "resty.core.time"
+ require "resty.core.misc"
++require "resty.core.hash"
+ 
+ 
+ if subsystem == 'http' then
+     require "resty.core.uri"
+-    require "resty.core.hash"
+     require "resty.core.base64"
+     require "resty.core.exit"
+     require "resty.core.var"
+diff --git a/lua-resty-core-0.1.17/lib/resty/core/hash.lua b/lua-resty-core-0.1.17/lib/resty/core/hash.lua
+index de97270..4a09b00 100644
+--- a/lua-resty-core-0.1.17/lib/resty/core/hash.lua
++++ b/lua-resty-core-0.1.17/lib/resty/core/hash.lua
+@@ -1,18 +1,27 @@
+ -- Copyright (C) Yichun Zhang (agentzh)
+ 
+ 
+-local ffi = require 'ffi'
+-local ffi_string = ffi.string
+-local ffi_new = ffi.new
++local ffi = require "ffi"
++local base = require "resty.core.base"
++
++
+ local C = ffi.C
++local ffi_new = ffi.new
++local ffi_string = ffi.string
+ local ngx = ngx
+ local type = type
+-local tostring = tostring
+ local error = error
+-local base = require "resty.core.base"
++local tostring = tostring
++local subsystem = ngx.config.subsystem
++
++
++local ngx_lua_ffi_md5
++local ngx_lua_ffi_md5_bin
++local ngx_lua_ffi_sha1_bin
+ 
+ 
+-ffi.cdef[[
++if subsystem == "http" then
++    ffi.cdef[[
+     void ngx_http_lua_ffi_md5_bin(const unsigned char *src, size_t len,
+                                   unsigned char *dst);
+ 
+@@ -21,7 +30,28 @@ ffi.cdef[[
+ 
+     int ngx_http_lua_ffi_sha1_bin(const unsigned char *src, size_t len,
+                                   unsigned char *dst);
+-]]
++    ]]
++
++    ngx_lua_ffi_md5 = C.ngx_http_lua_ffi_md5
++    ngx_lua_ffi_md5_bin = C.ngx_http_lua_ffi_md5_bin
++    ngx_lua_ffi_sha1_bin = C.ngx_http_lua_ffi_sha1_bin
++
++elseif subsystem == "stream" then
++    ffi.cdef[[
++    void ngx_stream_lua_ffi_md5_bin(const unsigned char *src, size_t len,
++                                    unsigned char *dst);
++
++    void ngx_stream_lua_ffi_md5(const unsigned char *src, size_t len,
++                                unsigned char *dst);
++
++    int ngx_stream_lua_ffi_sha1_bin(const unsigned char *src, size_t len,
++                                    unsigned char *dst);
++    ]]
++
++    ngx_lua_ffi_md5 = C.ngx_stream_lua_ffi_md5
++    ngx_lua_ffi_md5_bin = C.ngx_stream_lua_ffi_md5_bin
++    ngx_lua_ffi_sha1_bin = C.ngx_stream_lua_ffi_sha1_bin
++end
+ 
+ 
+ local MD5_DIGEST_LEN = 16
+@@ -35,7 +65,7 @@ ngx.md5_bin = function (s)
+             s = tostring(s)
+         end
+     end
+-    C.ngx_http_lua_ffi_md5_bin(s, #s, md5_buf)
++    ngx_lua_ffi_md5_bin(s, #s, md5_buf)
+     return ffi_string(md5_buf, MD5_DIGEST_LEN)
+ end
+ 
+@@ -51,7 +81,7 @@ ngx.md5 = function (s)
+             s = tostring(s)
+         end
+     end
+-    C.ngx_http_lua_ffi_md5(s, #s, md5_hex_buf)
++    ngx_lua_ffi_md5(s, #s, md5_hex_buf)
+     return ffi_string(md5_hex_buf, MD5_HEX_DIGEST_LEN)
+ end
+ 
+@@ -67,7 +97,7 @@ ngx.sha1_bin = function (s)
+             s = tostring(s)
+         end
+     end
+-    local ok = C.ngx_http_lua_ffi_sha1_bin(s, #s, sha_buf)
++    local ok = ngx_lua_ffi_sha1_bin(s, #s, sha_buf)
+     if ok == 0 then
+         error("SHA-1 support missing in Nginx")
+     end
+-- 
+2.26.2
+

--- a/openresty-patches/patches/1.15.8.3/lua-resty-core-0.1.17_05-ffi_crc32_api.patch
+++ b/openresty-patches/patches/1.15.8.3/lua-resty-core-0.1.17_05-ffi_crc32_api.patch
@@ -1,0 +1,99 @@
+From e3f3fad22b086f5079e2ca2cea0fa21a2634a355 Mon Sep 17 00:00:00 2001
+From: Thibault Charbonnier <thibaultcha@me.com>
+Date: Tue, 10 Sep 2019 11:47:32 -0700
+Subject: [PATCH] feature: implemented 'ngx.crc32_short()' and
+ 'ngx.crc32_long()' via FFI.
+
+---
+ lib/resty/core/hash.lua | 44 +++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 44 insertions(+)
+
+diff --git a/lua-resty-core-0.1.17/lib/resty/core/hash.lua b/lua-resty-core-0.1.17/lib/resty/core/hash.lua
+index 4a09b00..062f3ff 100644
+--- a/lua-resty-core-0.1.17/lib/resty/core/hash.lua
++++ b/lua-resty-core-0.1.17/lib/resty/core/hash.lua
+@@ -18,6 +18,8 @@ local subsystem = ngx.config.subsystem
+ local ngx_lua_ffi_md5
+ local ngx_lua_ffi_md5_bin
+ local ngx_lua_ffi_sha1_bin
++local ngx_lua_ffi_crc32_long
++local ngx_lua_ffi_crc32_short
+ 
+ 
+ if subsystem == "http" then
+@@ -30,11 +32,19 @@ if subsystem == "http" then
+ 
+     int ngx_http_lua_ffi_sha1_bin(const unsigned char *src, size_t len,
+                                   unsigned char *dst);
++
++    unsigned int ngx_http_lua_ffi_crc32_long(const unsigned char *src,
++                                             size_t len);
++
++    unsigned int ngx_http_lua_ffi_crc32_short(const unsigned char *src,
++                                              size_t len);
+     ]]
+ 
+     ngx_lua_ffi_md5 = C.ngx_http_lua_ffi_md5
+     ngx_lua_ffi_md5_bin = C.ngx_http_lua_ffi_md5_bin
+     ngx_lua_ffi_sha1_bin = C.ngx_http_lua_ffi_sha1_bin
++    ngx_lua_ffi_crc32_short = C.ngx_http_lua_ffi_crc32_short
++    ngx_lua_ffi_crc32_long = C.ngx_http_lua_ffi_crc32_long
+ 
+ elseif subsystem == "stream" then
+     ffi.cdef[[
+@@ -46,11 +56,19 @@ elseif subsystem == "stream" then
+ 
+     int ngx_stream_lua_ffi_sha1_bin(const unsigned char *src, size_t len,
+                                     unsigned char *dst);
++
++    unsigned int ngx_stream_lua_ffi_crc32_long(const unsigned char *src,
++                                               size_t len);
++
++    unsigned int ngx_stream_lua_ffi_crc32_short(const unsigned char *src,
++                                                size_t len);
+     ]]
+ 
+     ngx_lua_ffi_md5 = C.ngx_stream_lua_ffi_md5
+     ngx_lua_ffi_md5_bin = C.ngx_stream_lua_ffi_md5_bin
+     ngx_lua_ffi_sha1_bin = C.ngx_stream_lua_ffi_sha1_bin
++    ngx_lua_ffi_crc32_short = C.ngx_stream_lua_ffi_crc32_short
++    ngx_lua_ffi_crc32_long = C.ngx_stream_lua_ffi_crc32_long
+ end
+ 
+ 
+@@ -105,6 +123,32 @@ ngx.sha1_bin = function (s)
+ end
+ 
+ 
++ngx.crc32_short = function (s)
++    if type(s) ~= "string" then
++        if not s then
++            s = ""
++        else
++            s = tostring(s)
++        end
++    end
++
++    return ngx_lua_ffi_crc32_short(s, #s)
++end
++
++
++ngx.crc32_long = function (s)
++    if type(s) ~= "string" then
++        if not s then
++            s = ""
++        else
++            s = tostring(s)
++        end
++    end
++
++    return ngx_lua_ffi_crc32_long(s, #s)
++end
++
++
+ return {
+     version = base.version
+ }
+-- 
+2.26.2
+


### PR DESCRIPTION
* add the patch enabling FFI-based hashing APIs in stream subsystem
  (prerequisite).
* add the subsequent patch enabling FFI-based ngx.crc32 API used by the
  dynamic upstream keepalive patch.