### PR TITLE
chore(patches) make 1.17.8.1 and 1.17.8.2 patches to apply cleanly

### DIFF
--- a/openresty-patches/patches/1.17.8.1/LuaJIT-2.1-20200102_01-dyn-lightuserdata-map.patch
+++ b/openresty-patches/patches/1.17.8.1/LuaJIT-2.1-20200102_01-dyn-lightuserdata-map.patch
@@ -52,7 +52,7 @@ diff --git a/LuaJIT-2.1-20200102/src/lj_arch.h b/LuaJIT-2.1-20200102/src/lj_arch
 index 8f6bc52..cf1c641 100644
 --- a/LuaJIT-2.1-20200102/src/lj_arch.h
 +++ b/LuaJIT-2.1-20200102/src/lj_arch.h
-@@ -237,6 +237,7 @@
+@@ -241,6 +241,7 @@
  #define LJ_TARGET_MASKROT	1
  #define LJ_TARGET_UNIFYROT	2	/* Want only IR_BROR. */
  #define LJ_TARGET_GC64		1
@@ -77,7 +77,7 @@ diff --git a/LuaJIT-2.1-20200102/src/lj_obj.h b/LuaJIT-2.1-20200102/src/lj_obj.h
 index a89ea0d..77a157b 100644
 --- a/LuaJIT-2.1-20200102/src/lj_obj.h
 +++ b/LuaJIT-2.1-20200102/src/lj_obj.h
-@@ -830,6 +830,21 @@ typedef union GCobj {
+@@ -831,6 +831,21 @@ typedef union GCobj {
  #define setpriV(o, i)		(setitype((o), (i)))
  #endif
  

--- a/openresty-patches/patches/1.17.8.1/lua-resty-core-0.1.19_01-cosocket-mtls.patch
+++ b/openresty-patches/patches/1.17.8.1/lua-resty-core-0.1.19_01-cosocket-mtls.patch
@@ -392,8 +392,8 @@ diff --git a/lua-resty-core-0.1.19/lib/resty/core.lua b/lua-resty-core-0.1.19/li
 index 57c9d17..7e8aca4 100644
 --- a/lua-resty-core-0.1.19/lib/resty/core.lua
 +++ b/lua-resty-core-0.1.19/lib/resty/core.lua
-@@ -21,6 +21,7 @@ if subsystem == 'http' then
-     require "resty.core.worker"
+@@ -19,6 +19,7 @@ if subsystem == 'http' then
+     require "resty.core.response"
      require "resty.core.phase"
      require "resty.core.ndk"
 +    require "resty.core.socket_tcp"

--- a/openresty-patches/patches/1.17.8.1/lua-resty-core-0.1.19_03-upstream_recreate_request.patch
+++ b/openresty-patches/patches/1.17.8.1/lua-resty-core-0.1.19_03-upstream_recreate_request.patch
@@ -13,7 +13,7 @@ diff --git a/lua-resty-core-0.1.19/lib/ngx/balancer.lua b/lua-resty-core-0.1.19/
 index d584639..2bc16e1 100644
 --- a/lua-resty-core-0.1.19/lib/ngx/balancer.lua
 +++ b/lua-resty-core-0.1.19/lib/ngx/balancer.lua
-@@ -38,6 +38,10 @@ if subsystem == 'http' then
+@@ -45,6 +45,10 @@ if subsystem == 'http' then
      int ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
          long connect_timeout, long send_timeout,
          long read_timeout, char **err);
@@ -24,7 +24,7 @@ index d584639..2bc16e1 100644
      ]]
  
      ngx_lua_ffi_balancer_set_current_peer =
-@@ -207,4 +211,25 @@ function _M.set_timeouts(connect_timeout, send_timeout, read_timeout)
+@@ -344,4 +348,25 @@ function _M.set_timeouts(connect_timeout, send_timeout, read_timeout)
  end
  
  

--- a/openresty-patches/patches/1.17.8.1/nginx-1.17.8_01-upstream_client_certificate_and_ssl_verify.patch
+++ b/openresty-patches/patches/1.17.8.1/nginx-1.17.8_01-upstream_client_certificate_and_ssl_verify.patch
@@ -12,7 +12,7 @@ index 90710557..539a4db9 100644
 
 
  #if (NGX_HTTP_CACHE)
-@@ -1691,7 +1691,14 @@
+@@ -1688,7 +1688,14 @@
      c->sendfile = 0;
      u->output.sendfile = 0;
 
@@ -27,7 +27,7 @@ index 90710557..539a4db9 100644
          if (ngx_http_upstream_ssl_name(r, u, c) != NGX_OK) {
              ngx_http_upstream_finalize_request(r, u,
                                                 NGX_HTTP_INTERNAL_SERVER_ERROR);
-@@ -1719,6 +1722,10 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+@@ -1716,6 +1719,10 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
          }
      }
 
@@ -38,7 +38,7 @@ index 90710557..539a4db9 100644
      r->connection->log->action = "SSL handshaking to upstream";
 
      rc = ngx_ssl_handshake(c);
-@@ -1768,7 +1768,11 @@
+@@ -1765,7 +1765,11 @@
 
      if (c->ssl->handshaked) {
 

--- a/openresty-patches/patches/1.17.8.1/ngx_stream_lua-0.0.8_01-inject-req-time-api.patch
+++ b/openresty-patches/patches/1.17.8.1/ngx_stream_lua-0.0.8_01-inject-req-time-api.patch
@@ -12,10 +12,10 @@ diff --git a/ngx_stream_lua-0.0.8/src/ngx_stream_lua_util.c b/ngx_stream_lua-0.0
 index 313a8f4..f47a574 100644
 --- a/ngx_stream_lua-0.0.8/src/ngx_stream_lua_util.c
 +++ b/ngx_stream_lua-0.0.8/src/ngx_stream_lua_util.c
-@@ -1955,6 +1955,7 @@ ngx_stream_lua_inject_req_api(ngx_log_t *log, lua_State *L)
+@@ -1976,6 +1976,7 @@ ngx_stream_lua_inject_req_api(ngx_log_t *log, lua_State *L)
+
      lua_pushcfunction(L, ngx_stream_lua_req_socket);
      lua_setfield(L, -2, "socket");
-
 +    ngx_stream_lua_inject_req_time_api(L);
 
      lua_setfield(L, -2, "req");

--- a/openresty-patches/patches/1.17.8.2/LuaJIT-2.1-20200102_01-dyn-lightuserdata-map.patch
+++ b/openresty-patches/patches/1.17.8.2/LuaJIT-2.1-20200102_01-dyn-lightuserdata-map.patch
@@ -52,7 +52,7 @@ diff --git a/LuaJIT-2.1-20200102/src/lj_arch.h b/LuaJIT-2.1-20200102/src/lj_arch
 index 8f6bc52..cf1c641 100644
 --- a/LuaJIT-2.1-20200102/src/lj_arch.h
 +++ b/LuaJIT-2.1-20200102/src/lj_arch.h
-@@ -237,6 +237,7 @@
+@@ -241,6 +241,7 @@
  #define LJ_TARGET_MASKROT	1
  #define LJ_TARGET_UNIFYROT	2	/* Want only IR_BROR. */
  #define LJ_TARGET_GC64		1
@@ -77,7 +77,7 @@ diff --git a/LuaJIT-2.1-20200102/src/lj_obj.h b/LuaJIT-2.1-20200102/src/lj_obj.h
 index a89ea0d..77a157b 100644
 --- a/LuaJIT-2.1-20200102/src/lj_obj.h
 +++ b/LuaJIT-2.1-20200102/src/lj_obj.h
-@@ -830,6 +830,21 @@ typedef union GCobj {
+@@ -831,6 +831,21 @@ typedef union GCobj {
  #define setpriV(o, i)		(setitype((o), (i)))
  #endif
  

--- a/openresty-patches/patches/1.17.8.2/lua-resty-core-0.1.19_01-cosocket-mtls.patch
+++ b/openresty-patches/patches/1.17.8.2/lua-resty-core-0.1.19_01-cosocket-mtls.patch
@@ -392,8 +392,8 @@ diff --git a/lua-resty-core-0.1.19/lib/resty/core.lua b/lua-resty-core-0.1.19/li
 index 57c9d17..7e8aca4 100644
 --- a/lua-resty-core-0.1.19/lib/resty/core.lua
 +++ b/lua-resty-core-0.1.19/lib/resty/core.lua
-@@ -21,6 +21,7 @@ if subsystem == 'http' then
-     require "resty.core.worker"
+@@ -19,6 +19,7 @@ if subsystem == 'http' then
+     require "resty.core.response"
      require "resty.core.phase"
      require "resty.core.ndk"
 +    require "resty.core.socket_tcp"

--- a/openresty-patches/patches/1.17.8.2/lua-resty-core-0.1.19_03-upstream_recreate_request.patch
+++ b/openresty-patches/patches/1.17.8.2/lua-resty-core-0.1.19_03-upstream_recreate_request.patch
@@ -13,7 +13,7 @@ diff --git a/lua-resty-core-0.1.19/lib/ngx/balancer.lua b/lua-resty-core-0.1.19/
 index d584639..2bc16e1 100644
 --- a/lua-resty-core-0.1.19/lib/ngx/balancer.lua
 +++ b/lua-resty-core-0.1.19/lib/ngx/balancer.lua
-@@ -38,6 +38,10 @@ if subsystem == 'http' then
+@@ -45,6 +45,10 @@ if subsystem == 'http' then
      int ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
          long connect_timeout, long send_timeout,
          long read_timeout, char **err);
@@ -24,7 +24,7 @@ index d584639..2bc16e1 100644
      ]]
  
      ngx_lua_ffi_balancer_set_current_peer =
-@@ -207,4 +211,25 @@ function _M.set_timeouts(connect_timeout, send_timeout, read_timeout)
+@@ -344,4 +348,25 @@ function _M.set_timeouts(connect_timeout, send_timeout, read_timeout)
  end
  
  

--- a/openresty-patches/patches/1.17.8.2/nginx-1.17.8_01-upstream_client_certificate_and_ssl_verify.patch
+++ b/openresty-patches/patches/1.17.8.2/nginx-1.17.8_01-upstream_client_certificate_and_ssl_verify.patch
@@ -12,7 +12,7 @@ index 90710557..539a4db9 100644
 
 
  #if (NGX_HTTP_CACHE)
-@@ -1691,7 +1691,14 @@
+@@ -1688,7 +1688,14 @@
      c->sendfile = 0;
      u->output.sendfile = 0;
 
@@ -27,7 +27,7 @@ index 90710557..539a4db9 100644
          if (ngx_http_upstream_ssl_name(r, u, c) != NGX_OK) {
              ngx_http_upstream_finalize_request(r, u,
                                                 NGX_HTTP_INTERNAL_SERVER_ERROR);
-@@ -1719,6 +1722,10 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
+@@ -1716,6 +1719,10 @@ ngx_http_upstream_ssl_init_connection(ngx_http_request_t *r,
          }
      }
 
@@ -38,7 +38,7 @@ index 90710557..539a4db9 100644
      r->connection->log->action = "SSL handshaking to upstream";
 
      rc = ngx_ssl_handshake(c);
-@@ -1768,7 +1768,11 @@
+@@ -1765,7 +1765,11 @@
 
      if (c->ssl->handshaked) {
 

--- a/openresty-patches/patches/1.17.8.2/ngx_stream_lua-0.0.8_01-inject-req-time-api.patch
+++ b/openresty-patches/patches/1.17.8.2/ngx_stream_lua-0.0.8_01-inject-req-time-api.patch
@@ -12,10 +12,10 @@ diff --git a/ngx_stream_lua-0.0.8/src/ngx_stream_lua_util.c b/ngx_stream_lua-0.0
 index 313a8f4..f47a574 100644
 --- a/ngx_stream_lua-0.0.8/src/ngx_stream_lua_util.c
 +++ b/ngx_stream_lua-0.0.8/src/ngx_stream_lua_util.c
-@@ -1955,6 +1955,7 @@ ngx_stream_lua_inject_req_api(ngx_log_t *log, lua_State *L)
+@@ -1976,6 +1976,7 @@ ngx_stream_lua_inject_req_api(ngx_log_t *log, lua_State *L)
+
      lua_pushcfunction(L, ngx_stream_lua_req_socket);
      lua_setfield(L, -2, "socket");
-
 +    ngx_stream_lua_inject_req_time_api(L);
 
      lua_setfield(L, -2, "req");


### PR DESCRIPTION
### Summary

```
patching file LuaJIT-2.1-20200102/src/lj_api.c
patching file LuaJIT-2.1-20200102/src/lj_arch.h
Hunk #1 succeeded at 241 (offset 4 lines).
patching file LuaJIT-2.1-20200102/src/lj_cconv.c
patching file LuaJIT-2.1-20200102/src/lj_obj.h
Hunk #1 succeeded at 831 (offset 1 line).
patching file LuaJIT-2.1-20200102/src/lj_state.c
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/resty/core.lua
Hunk #1 succeeded at 19 with fuzz 1 (offset -2 lines).
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/ngx/balancer.lua
patching file lua-resty-core-0.1.19/lib/ngx/balancer.lua
Hunk #1 succeeded at 45 (offset 7 lines).
Hunk #2 succeeded at 348 (offset 137 lines).
patching file lua-resty-core-0.1.19/lib/resty/core.lua
patching file lua-resty-core-0.1.19/lib/resty/core/request.lua
patching file lua-resty-core-0.1.19/lib/resty/core/utils.lua
patching file lua-resty-websocket-0.07/lib/resty/websocket/client.lua
patching file nginx-1.17.8/src/http/ngx_http_upstream.c
Hunk #2 succeeded at 1688 (offset -3 lines).
Hunk #3 succeeded at 1719 (offset -3 lines).
Hunk #4 succeeded at 1765 (offset -3 lines).
patching file nginx-1.17.8/src/http/ngx_http_special_response.c
patching file nginx-1.17.8/src/stream/ngx_stream_proxy_module.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.h
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_balancer.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_common.h
patching file ngx_lua-0.10.17/src/ngx_http_lua_module.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_balancer.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_balancer.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_common.h
patching file ngx_lua-0.10.17/src/ngx_http_lua_balancer.c
patching file ngx_stream_lua-0.0.8/src/ngx_stream_lua_util.c
Hunk #1 succeeded at 1965 with fuzz 2 (offset 10 lines).
patching file ngx_stream_lua-0.0.8/src/api/ngx_stream_lua_api.h
```

vs.

```
patching file LuaJIT-2.1-20200102/src/lj_api.c
patching file LuaJIT-2.1-20200102/src/lj_arch.h
patching file LuaJIT-2.1-20200102/src/lj_cconv.c
patching file LuaJIT-2.1-20200102/src/lj_obj.h
patching file LuaJIT-2.1-20200102/src/lj_state.c
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/resty/core.lua
patching file lua-resty-core-0.1.19/lib/resty/core/socket_tcp.lua
patching file lua-resty-core-0.1.19/lib/ngx/balancer.lua
patching file lua-resty-core-0.1.19/lib/ngx/balancer.lua
patching file lua-resty-core-0.1.19/lib/resty/core.lua
patching file lua-resty-core-0.1.19/lib/resty/core/request.lua
patching file lua-resty-core-0.1.19/lib/resty/core/utils.lua
patching file lua-resty-websocket-0.07/lib/resty/websocket/client.lua
patching file nginx-1.17.8/src/http/ngx_http_upstream.c
patching file nginx-1.17.8/src/http/ngx_http_special_response.c
patching file nginx-1.17.8/src/stream/ngx_stream_proxy_module.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.h
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_socket_tcp.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_balancer.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_common.h
patching file ngx_lua-0.10.17/src/ngx_http_lua_module.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_balancer.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_balancer.c
patching file ngx_lua-0.10.17/src/ngx_http_lua_common.h
patching file ngx_lua-0.10.17/src/ngx_http_lua_balancer.c
patching file ngx_stream_lua-0.0.8/src/ngx_stream_lua_util.c
patching file ngx_stream_lua-0.0.8/src/api/ngx_stream_lua_api.h
```