### PR TITLE
fix(cache) utilize luarocks purge --old-versions to keep our luarocks current

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,8 @@ pipeline {
             }
             steps {
                 sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
+                sh 'make cleanup'
+                sh 'rm -rf $KONG_SOURCE_LOCATION || true'
                 sh 'git clone --single-branch --branch $KONG_SOURCE https://github.com/Kong/kong.git $KONG_SOURCE_LOCATION'
                 sh 'make kong-test-container'
             }

--- a/build-kong.sh
+++ b/build-kong.sh
@@ -33,6 +33,7 @@ pushd /kong
 
   mkdir -p /tmp/plugin
   
+  luarocks purge --tree=/tmp/build/usr/local --old-versions || true
   /usr/local/bin/luarocks make kong-${ROCKSPEC_VERSION}.rockspec \
     CRYPTO_DIR=/usr/local/kong \
     OPENSSL_DIR=/usr/local/kong \


### PR DESCRIPTION
The following PR https://github.com/Kong/kong/pull/6361/files per
![image](https://user-images.githubusercontent.com/697188/95362338-f21ef400-089b-11eb-9f44-37d4d39111c4.png)

should have upgraded both lua-resty-worker-events and lua-resty-healthcheck but fails.

![image](https://user-images.githubusercontent.com/697188/95362317-e9c6b900-089b-11eb-97f5-0fa42f287db2.png)

I believe this design is correct / safe but as a result we should make sure the openresty container we build our test container on top of doesn't have any installed luarocks