### PR TITLE
fix: remove / reinstall luarocks to make sure we catch version bumps

### DIFF
--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -50,6 +50,12 @@ COPY kong /kong
 RUN mkdir -p /kong/servroot/logs
 RUN chmod -R 777 /kong
 WORKDIR /kong
+RUN luarocks purge --tree=/usr/local || true
+RUN /usr/local/bin/luarocks make kong-*.rockspec \
+    CRYPTO_DIR=/usr/local/kong \
+    OPENSSL_DIR=/usr/local/kong \
+    YAML_LIBDIR=/usr/local/kong/lib \
+    CFLAGS="-L/usr/local/kong/lib -Wl,-rpath,/usr/local/kong/lib -O2 -fPIC"
 RUN make dev
 
 RUN curl -L https://cpanmin.us | perl - App::cpanminus \


### PR DESCRIPTION
when we only pin the major/minor of a luarock ie `~1.1` when the luarock releases a new patch `1.1.5` we need to ensure the new version gets installed.

I believe we can/should resolve this using [luarocks dependency locking ](https://github.com/luarocks/luarocks/blob/master/CHANGELOG.md#whats-new-in-luarocks-330) such that after running `make dev` one is fully up to date. Until then this effectively purges / reinstalls all `luarocks`