### PR TITLE
feat(openresty-patches) add patch to fix resty-cli; delete /tmp dirs

### DIFF
--- a/openresty-patches/patches/1.17.8.1/resty-cli-0.25-fix_tmp_directory_deletion.patch
+++ b/openresty-patches/patches/1.17.8.1/resty-cli-0.25-fix_tmp_directory_deletion.patch
@@ -1,0 +1,11 @@
+--- bundle/resty-cli-0.25/bin/resty
++++ bundle/resty-cli-0.25/bin/resty
+@@ -623,7 +623,7 @@
+ my $child_pid;
+ 
+ END {
+-    if (!$is_win32 && !defined($child_pid) && defined $prefix_dir) {
++    if (!$is_win32 && defined($child_pid) && defined $prefix_dir) {
+         my $saved_status = $?;
+         system("rm -rf $prefix_dir") == 0
+             or warn "failed to remove temp directory $prefix_dir: $!";

--- a/openresty-patches/patches/1.17.8.2/resty-cli-0.25-fix_tmp_directory_deletion.patch
+++ b/openresty-patches/patches/1.17.8.2/resty-cli-0.25-fix_tmp_directory_deletion.patch
@@ -1,0 +1,11 @@
+--- bundle/resty-cli-0.25/bin/resty
++++ bundle/resty-cli-0.25/bin/resty
+@@ -623,7 +623,7 @@
+ my $child_pid;
+ 
+ END {
+-    if (!$is_win32 && !defined($child_pid) && defined $prefix_dir) {
++    if (!$is_win32 && defined($child_pid) && defined $prefix_dir) {
+         my $saved_status = $?;
+         system("rm -rf $prefix_dir") == 0
+             or warn "failed to remove temp directory $prefix_dir: $!";


### PR DESCRIPTION
resty-cli does not properly delete `/tmp/resty_*` directories. This is only required for OpenResty versions 1.17.8.x due to the use of resty-cli v0.25; v0.26 fixed the issue and has been made available in later versions of OpenResty.

Related: https://github.com/openresty/resty-cli/pull/58