### PR TITLE
chore(kong-ngx-build) use newer lua-resty-dns

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -217,6 +217,16 @@ main() {
           echo "$OPENRESTY_SHA openresty-$OPENRESTY_VER.tar.gz" | sha256sum -c -
         fi
         tar -xzf openresty-$OPENRESTY_VER.tar.gz
+
+        # use unreleased version of lua-resty-dns
+        if version_eq $OPENRESTY_VER 1.19.3; then
+          pushd openresty-$OPENRESTY_VER/bundle
+            notice "Updating lua-resty-dns to unreleased version"
+            curl -sSL https://github.com/openresty/lua-resty-dns/tarball/ad4a51c8cae8c3fb8f712fa91fda660ab8a89669 -o lua-resty-dns-0.21.tar.gz && \
+            tar -xzf lua-resty-dns-0.21.tar.gz --keep-newer-files -C lua-resty-dns-0.21 --strip-components 1 && \
+            rm -f lua-resty-dns-0.21.tar.gz
+          popd
+        fi
       fi
     fi
 


### PR DESCRIPTION
We need to use the latest lua-resty-dns which is not yet released. This PR overwrites the one bundled in OpenResty with the (currently) latest, using the commit SHA hash.