### PR TITLE
chore(postgres) bump test Postgres version to 13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       retries: 10
     restart: on-failure
   postgres:
-    image: postgres:${POSTGRES_VERSION:-9.5}
+    image: postgres:${POSTGRES_VERSION:-13}
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB: ${KONG_PG_DATABASE:-kong_tests}

--- a/test/kong-tests-compose.yaml
+++ b/test/kong-tests-compose.yaml
@@ -71,7 +71,7 @@ services:
       - "127.0.0.1:8444:8444/tcp"
 
   db:
-    image: postgres:9.5
+    image: postgres:13
     ports:
       - '5432:5432'
     expose:


### PR DESCRIPTION
Postgres 9.5 is 5 years old and EOL already:

https://www.postgresql.org/support/versioning/

Approve but do not merge until after 2.4 GA.