### PR TITLE
chore(ci) change default kong branch to master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
         cron(env.BRANCH_NAME == 'master' ? '@weekly' : '')
     }
     environment {
-        KONG_SOURCE = "next"
+        KONG_SOURCE = "master"
         KONG_SOURCE_LOCATION = "/tmp/kong"
         DOCKER_USERNAME = "${env.DOCKERHUB_USR}"
         DOCKER_PASSWORD = "${env.DOCKERHUB_PSW}"


### PR DESCRIPTION
Kong no longer uses the next branch. All PRs are merged into
master.