### PR TITLE
fix(openresty-build-tools) remove lua-resty-dns .tar.gz in MacOS

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -222,8 +222,8 @@ main() {
         if version_eq $OPENRESTY_VER 1.19.3; then
           pushd openresty-$OPENRESTY_VER/bundle
             notice "Updating lua-resty-dns to unreleased version"
-            curl -sSL https://github.com/openresty/lua-resty-dns/tarball/ad4a51c8cae8c3fb8f712fa91fda660ab8a89669 -o lua-resty-dns-0.21.tar.gz && \
-            tar -xzf lua-resty-dns-0.21.tar.gz --keep-newer-files -C lua-resty-dns-0.21 --strip-components 1 && \
+            curl -sSL https://github.com/openresty/lua-resty-dns/tarball/ad4a51c8cae8c3fb8f712fa91fda660ab8a89669 -o lua-resty-dns-0.21.tar.gz
+            tar -xzf lua-resty-dns-0.21.tar.gz --keep-newer-files -C lua-resty-dns-0.21 --strip-components 1
             rm -f lua-resty-dns-0.21.tar.gz
           popd
         fi


### PR DESCRIPTION
Chaining these actions with `&&` made the `rm -rf` never occur in MacOS.

The `--keep-newer-files` option was making `tar` uncompress the files,
but it was also generating warnings and eventually exiting with a non-0
status.

As a result the .tar.gz file was never removed. When openresty tries to
process lua-resty-dns it got confused by the .tar.gz and would error
with "Multiple entries for lua-resty-dns".