### PR TITLE
test(rpm): test that our rpm's are signed

### DIFF
--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -10,9 +10,7 @@ if [[ "$PACKAGE_TYPE" == "rpm" ]]; then
   cp $PACKAGE_LOCATION/*amd64.rpm kong.rpm
   docker exec ${USE_TTY} user-validation-tests /bin/bash -c "yum install -y /src/kong.rpm"
   docker exec ${USE_TTY} user-validation-tests /bin/bash -c "kong version"
-  docker exec ${USE_TTY} user-validation-tests /bin/bash -c "yum install -y wget"
-  docker exec ${USE_TTY} user-validation-tests /bin/bash -c "wget https://download.konghq.com/gateway-2.x-rhel-8/repodata/repomd.xml.key"
-  docker exec ${USE_TTY} user-validation-tests /bin/bash -c "rpm --import repomd.xml.key"
+  docker exec ${USE_TTY} user-validation-tests /bin/bash -c "rpm --import https://download.konghq.com/gateway-2.x-rhel-8/repodata/repomd.xml.key"
   docker exec ${USE_TTY} user-validation-tests /bin/bash -c "rpm --checksig /src/kong.rpm"
 fi
 


### PR DESCRIPTION
A slack conversation had me notice we don't have a check in place that our RPM's are signed.

This adds a somewhat naive but effective check that our distributed public key can be used to validate our signed packages