### PR TITLE
chore(patches) handpicked a couple of LuaJIT patches needed for macOS+M1

### DIFF
--- a/openresty-patches/patches/1.19.9.1/LuaJIT-2.1-20210510_01-ffi-arm64-macos-fix-vararg-call-handling.patch
+++ b/openresty-patches/patches/1.19.9.1/LuaJIT-2.1-20210510_01-ffi-arm64-macos-fix-vararg-call-handling.patch
@@ -1,0 +1,62 @@
+From 521b367567dc5d91d7f9ae29c257998953e24e53 Mon Sep 17 00:00:00 2001
+From: Mike Pall <mike>
+Date: Sun, 2 May 2021 22:11:05 +0200
+Subject: [PATCH] FFI/ARM64/OSX: Fix vararg call handling.
+
+Thanks to Igor Munkin.
+---
+ LuaJIT-2.1-20210510/src/lj_ccall.c     | 8 ++++----
+ LuaJIT-2.1-20210510/src/lj_ccallback.c | 2 +-
+ 2 files changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/LuaJIT-2.1-20210510/src/lj_ccall.c b/LuaJIT-2.1-20210510/src/lj_ccall.c
+index a91ffc7e..3c029823 100644
+--- a/LuaJIT-2.1-20210510/src/lj_ccall.c
++++ b/LuaJIT-2.1-20210510/src/lj_ccall.c
+@@ -334,7 +334,7 @@
+   isfp = sz == 2*sizeof(float) ? 2 : 1;
+ 
+ #define CCALL_HANDLE_REGARG \
+-  if (LJ_TARGET_IOS && isva) { \
++  if (LJ_TARGET_OSX && isva) { \
+     /* IOS: All variadic arguments are on the stack. */ \
+   } else if (isfp) {  /* Try to pass argument in FPRs. */ \
+     int n2 = ctype_isvector(d->info) ? 1 : \
+@@ -345,10 +345,10 @@
+       goto done; \
+     } else { \
+       nfpr = CCALL_NARG_FPR;  /* Prevent reordering. */ \
+-      if (LJ_TARGET_IOS && d->size < 8) goto err_nyi; \
++      if (LJ_TARGET_OSX && d->size < 8) goto err_nyi; \
+     } \
+   } else {  /* Try to pass argument in GPRs. */ \
+-    if (!LJ_TARGET_IOS && (d->info & CTF_ALIGN) > CTALIGN_PTR) \
++    if (!LJ_TARGET_OSX && (d->info & CTF_ALIGN) > CTALIGN_PTR) \
+       ngpr = (ngpr + 1u) & ~1u;  /* Align to regpair. */ \
+     if (ngpr + n <= maxgpr) { \
+       dp = &cc->gpr[ngpr]; \
+@@ -356,7 +356,7 @@
+       goto done; \
+     } else { \
+       ngpr = maxgpr;  /* Prevent reordering. */ \
+-      if (LJ_TARGET_IOS && d->size < 8) goto err_nyi; \
++      if (LJ_TARGET_OSX && d->size < 8) goto err_nyi; \
+     } \
+   }
+ 
+diff --git a/LuaJIT-2.1-20210510/src/lj_ccallback.c b/LuaJIT-2.1-20210510/src/lj_ccallback.c
+index 8d6cb737..80d738c6 100644
+--- a/LuaJIT-2.1-20210510/src/lj_ccallback.c
++++ b/LuaJIT-2.1-20210510/src/lj_ccallback.c
+@@ -460,7 +460,7 @@ void lj_ccallback_mcode_free(CTState *cts)
+       nfpr = CCALL_NARG_FPR;  /* Prevent reordering. */ \
+     } \
+   } else { \
+-    if (!LJ_TARGET_IOS && n > 1) \
++    if (!LJ_TARGET_OSX && n > 1) \
+       ngpr = (ngpr + 1u) & ~1u;  /* Align to regpair. */ \
+     if (ngpr + n <= maxgpr) { \
+       sp = &cts->cb.gpr[ngpr]; \
+-- 
+2.34.1
+

--- a/openresty-patches/patches/1.19.9.1/LuaJIT-2.1-20210510_02-arm64-fix-pcall-error-case.patch
+++ b/openresty-patches/patches/1.19.9.1/LuaJIT-2.1-20210510_02-arm64-fix-pcall-error-case.patch
@@ -1,0 +1,29 @@
+From b4b2dce9fc3ffaaaede39b36d06415311e2aa516 Mon Sep 17 00:00:00 2001
+From: Mike Pall <mike>
+Date: Wed, 27 Oct 2021 21:56:07 +0200
+Subject: [PATCH] ARM64: Fix pcall() error case.
+
+Reported by Alex Orlenko.
+---
+ src/vm_arm64.dasc | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/LuaJIT-2.1-20210510/src/vm_arm64.dasc b/LuaJIT-2.1-20210510/src/vm_arm64.dasc
+index c7090ca3..eb87857f 100644
+--- a/LuaJIT-2.1-20210510/src/vm_arm64.dasc
++++ b/LuaJIT-2.1-20210510/src/vm_arm64.dasc
+@@ -1163,9 +1163,10 @@ static void build_subroutines(BuildCtx *ctx)
+   |//-- Base library: catch errors ----------------------------------------
+   |
+   |.ffunc pcall
++  |   cmp NARGS8:RC, #8
+   |  ldrb TMP0w, GL->hookmask
+-  |   subs NARGS8:RC, NARGS8:RC, #8
+   |   blo ->fff_fallback
++  |   sub NARGS8:RC, NARGS8:RC, #8
+   |    mov RB, BASE
+   |    add BASE, BASE, #16
+   |  ubfx TMP0w, TMP0w, #HOOK_ACTIVE_SHIFT, #1
+-- 
+2.34.1
+

--- a/openresty-patches/patches/1.19.9.1/lua-resty-core-0.1.22_03-make-resty.core.shdict-compatible-with-m1.patch
+++ b/openresty-patches/patches/1.19.9.1/lua-resty-core-0.1.22_03-make-resty.core.shdict-compatible-with-m1.patch
@@ -1,0 +1,270 @@
+From 85202b4306db143de55926564bf6ce981f3631b4 Mon Sep 17 00:00:00 2001
+From: Aapo Talvensaari <aapo.talvensaari@gmail.com>
+Date: Thu, 16 Dec 2021 19:28:43 +0200
+Subject: [PATCH] fix(shdict) make resty.core.shdict compatible with m1 (using
+ wrappers)
+
+---
+ lua-resty-core-0.1.22/lib/resty/core/shdict.lua | 174 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 174 insertions(+)
+
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/shdict.lua b/lua-resty-core-0.1.22/lib/resty/core/shdict.lua
+index dedf12c..e501a38 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/shdict.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/shdict.lua
+@@ -32,8 +32,11 @@ local subsystem = ngx.config.subsystem
+ 
+ 
+ local ngx_lua_ffi_shdict_get
++local ngx_lua_ffi_shdict_get_m1
+ local ngx_lua_ffi_shdict_incr
++local ngx_lua_ffi_shdict_incr_m1
+ local ngx_lua_ffi_shdict_store
++local ngx_lua_ffi_shdict_store_m1
+ local ngx_lua_ffi_shdict_flush_all
+ local ngx_lua_ffi_shdict_get_ttl
+ local ngx_lua_ffi_shdict_set_expire
+@@ -42,6 +45,53 @@ local ngx_lua_ffi_shdict_free_space
+ local ngx_lua_ffi_shdict_udata_to_zone
+ 
+ 
++local M1 = jit and jit.os == "OSX" and jit.arch == "arm64"
++if M1 then
++    ffi.cdef[[
++typedef struct {
++    void *zone;
++    const unsigned char *key;
++    size_t key_len;
++    int *value_type;
++    unsigned char **str_value_buf;
++    size_t *str_value_len;
++    double *num_value;
++    int *user_flags;
++    int get_stale;
++    int *is_stale;
++    char **errmsg;
++} ngx_shdict_get_t;
++
++typedef struct {
++    void *zone;
++    int op;
++    const unsigned char *key;
++    size_t key_len;
++    int value_type;
++    const unsigned char *str_value_buf;
++    size_t str_value_len;
++    double num_value;
++    long exptime;
++    int user_flags;
++    char **errmsg;
++    int *forcible;
++} ngx_shdict_store_t;
++
++typedef struct {
++    void *zone;
++    const unsigned char *key;
++    size_t key_len;
++    double *num_value;
++    char **errmsg;
++    int has_init;
++    double init;
++    long init_ttl;
++    int *forcible;
++} ngx_shdict_incr_t;
++]]
++end
++
++
+ if subsystem == 'http' then
+     ffi.cdef[[
+ int ngx_http_lua_ffi_shdict_get(void *zone, const unsigned char *key,
+@@ -72,6 +122,18 @@ size_t ngx_http_lua_ffi_shdict_capacity(void *zone);
+ void *ngx_http_lua_ffi_shdict_udata_to_zone(void *zone_udata);
+     ]]
+ 
++    if M1 then
++        ffi.cdef [[
++int ngx_http_lua_ffi_shdict_get_m1(ngx_shdict_get_t *s);
++int ngx_http_lua_ffi_shdict_store_m1(ngx_shdict_store_t *s);
++int ngx_http_lua_ffi_shdict_incr_m1(ngx_shdict_incr_t *s);
++    ]]
++
++        ngx_lua_ffi_shdict_get_m1 = C.ngx_http_lua_ffi_shdict_get_m1
++        ngx_lua_ffi_shdict_store_m1 = C.ngx_http_lua_ffi_shdict_store_m1
++        ngx_lua_ffi_shdict_incr_m1 = C.ngx_http_lua_ffi_shdict_incr_m1
++    end
++
+     ngx_lua_ffi_shdict_get = C.ngx_http_lua_ffi_shdict_get
+     ngx_lua_ffi_shdict_incr = C.ngx_http_lua_ffi_shdict_incr
+     ngx_lua_ffi_shdict_store = C.ngx_http_lua_ffi_shdict_store
+@@ -126,6 +188,17 @@ size_t ngx_stream_lua_ffi_shdict_capacity(void *zone);
+ void *ngx_stream_lua_ffi_shdict_udata_to_zone(void *zone_udata);
+     ]]
+ 
++    if M1 then
++        ffi.cdef [[
++int ngx_stream_lua_ffi_shdict_get_m1(ngx_shdict_get_t *s);
++int ngx_stream_lua_ffi_shdict_store_m1(ngx_shdict_store_t *s);
++int ngx_stream_lua_ffi_shdict_incr_m1(ngx_shdict_incr_t *s);
++    ]]
++        ngx_lua_ffi_shdict_get_m1 = C.ngx_stream_lua_ffi_shdict_get_m1
++        ngx_lua_ffi_shdict_store_m1 = C.ngx_stream_lua_ffi_shdict_store_m1
++        ngx_lua_ffi_shdict_incr_m1 = C.ngx_stream_lua_ffi_shdict_incr_m1
++    end
++
+     ngx_lua_ffi_shdict_get = C.ngx_stream_lua_ffi_shdict_get
+     ngx_lua_ffi_shdict_incr = C.ngx_stream_lua_ffi_shdict_incr
+     ngx_lua_ffi_shdict_store = C.ngx_stream_lua_ffi_shdict_store
+@@ -245,6 +318,31 @@ local function shdict_store(zone, op, key, value, exptime, flags)
+         return nil, "bad value type"
+     end
+ 
++    local rc
++    if M1 then
++        local q = ffi_new("ngx_shdict_store_t")
++        q.zone = zone
++        q.op = op
++        q.key = key
++        q.key_len = key_len
++        q.value_type = valtyp
++        q.str_value_buf = str_val_buf
++        q.str_value_len = str_val_len
++        q.num_value = num_val
++        q.exptime = exptime * 1000
++        q.user_flags = flags
++        q.errmsg = errmsg
++        q.forcible = forcible
++
++        local rc = ngx_lua_ffi_shdict_store_m1(q)
++        if rc == 0 then  -- NGX_OK
++            return true, nil, forcible[0] == 1
++        end
++
++        -- NGX_DECLINED or NGX_ERROR
++        return false, ffi_str(errmsg[0]), forcible[0] == 1
++    end
++
+     local rc = ngx_lua_ffi_shdict_store(zone, op, key, key_len,
+                                         valtyp, str_val_buf,
+                                         str_val_len, num_val,
+@@ -317,6 +415,30 @@ local function shdict_get(zone, key)
+     local value_len = get_size_ptr()
+     value_len[0] = size
+ 
++    if M1 then
++        local q = ffi_new("ngx_shdict_get_t")
++        q.zone = zone
++        q.key = key
++        q.key_len = key_len
++        q.value_type = value_type
++        q.str_value_buf = str_value_buf
++        q.str_value_len = value_len
++        q.num_value = num_value
++        q.user_flags = user_flags
++        q.get_stale = 0
++        q.is_stale = is_stale
++        q.errmsg = errmsg
++
++        local rc = ngx_lua_ffi_shdict_get_m1(q)
++        if rc ~= 0 then
++            if errmsg[0] ~= nil then
++                return nil, ffi_str(errmsg[0])
++            end
++
++            error("failed to get the key")
++        end
++    else
++
+     local rc = ngx_lua_ffi_shdict_get(zone, key, key_len, value_type,
+                                       str_value_buf, value_len,
+                                       num_value, user_flags, 0,
+@@ -329,6 +451,8 @@ local function shdict_get(zone, key)
+         error("failed to get the key")
+     end
+ 
++    end
++
+     local typ = value_type[0]
+ 
+     if typ == 0 then -- LUA_TNIL
+@@ -392,6 +516,30 @@ local function shdict_get_stale(zone, key)
+     local value_len = get_size_ptr()
+     value_len[0] = size
+ 
++    if M1 then
++        local q = ffi_new("ngx_shdict_get_t")
++        q.zone = zone
++        q.key = key
++        q.key_len = key_len
++        q.value_type = value_type
++        q.str_value_buf = str_value_buf
++        q.str_value_len = value_len
++        q.num_value = num_value
++        q.user_flags = user_flags
++        q.get_stale = 1
++        q.is_stale = is_stale
++        q.errmsg = errmsg
++
++        local rc = ngx_lua_ffi_shdict_get_m1(q)
++        if rc ~= 0 then
++            if errmsg[0] ~= nil then
++                return nil, ffi_str(errmsg[0])
++            end
++
++            error("failed to get the key")
++        end
++    else
++
+     local rc = ngx_lua_ffi_shdict_get(zone, key, key_len, value_type,
+                                       str_value_buf, value_len,
+                                       num_value, user_flags, 1,
+@@ -404,6 +552,8 @@ local function shdict_get_stale(zone, key)
+         error("failed to get the key")
+     end
+ 
++    end
++
+     local typ = value_type[0]
+ 
+     if typ == 0 then -- LUA_TNIL
+@@ -498,6 +648,28 @@ local function shdict_incr(zone, key, value, init, init_ttl)
+         init_ttl = 0
+     end
+ 
++    if M1 then
++        local q = ffi_new("ngx_shdict_incr_t")
++        q.zone = zone
++        q.key = key
++        q.key_len = key_len
++        q.num_value = num_value
++        q.errmsg = errmsg
++        if init then
++            q.has_init = 1
++            q.init = init
++        else
++            q.has_init = 0
++        end
++        q.init_ttl = init_ttl * 1000
++        q.forcible = forcible
++
++        local rc = ngx_lua_ffi_shdict_incr_m1(q)
++        if rc ~= 0 then  -- ~= NGX_OK
++            return nil, ffi_str(errmsg[0])
++        end
++    else
++
+     local rc = ngx_lua_ffi_shdict_incr(zone, key, key_len, num_value,
+                                        errmsg, init and 1 or 0,
+                                        init or 0, init_ttl * 1000,
+@@ -506,6 +678,8 @@ local function shdict_incr(zone, key, value, init, init_ttl)
+         return nil, ffi_str(errmsg[0])
+     end
+ 
++    end
++
+     if not init then
+         return tonumber(num_value[0])
+     end
+-- 
+2.34.1
+

--- a/openresty-patches/patches/1.19.9.1/lua-resty-core-0.1.22_04-make-resty.core.response-compatible-with-m1.patch
+++ b/openresty-patches/patches/1.19.9.1/lua-resty-core-0.1.22_04-make-resty.core.response-compatible-with-m1.patch
@@ -1,0 +1,101 @@
+From 94efefb9aaede738ec9e29e639cf5e934e9a1d5a Mon Sep 17 00:00:00 2001
+From: Aapo Talvensaari <aapo.talvensaari@gmail.com>
+Date: Thu, 16 Dec 2021 19:28:13 +0200
+Subject: [PATCH] fix(response) make resty.core.response compatible with m1
+ (using kong wrappers)
+
+---
+ lua-resty-core-0.1.22/lib/resty/core/response.lua | 58 +++++++++++++++++++++++++++++++++++++
+ 1 file changed, 58 insertions(+)
+
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/response.lua b/lua-resty-core-0.1.22/lib/resty/core/response.lua
+index 891a07e..1efdf56 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/response.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/response.lua
+@@ -45,6 +45,27 @@ ffi.cdef[[
+ ]]
+ 
+ 
++local M1 = jit and jit.os == "OSX" and jit.arch == "arm64"
++if M1 then
++ffi.cdef[[
++    typedef struct {
++    ngx_http_request_t *r;
++    const char *key_data;
++    size_t key_len;
++    int is_nil;
++    const char *sval;
++    size_t sval_len;
++    void *mvals;
++    size_t mvals_len;
++    int override;
++    char **errmsg;
++    } ngx_set_resp_header_t;
++
++    int ngx_http_lua_ffi_set_resp_header_m1(ngx_set_resp_header_t *s);
++]]
++end
++
++
+ local function set_resp_header(tb, key, value, no_override)
+     local r = get_request()
+     if not r then
+@@ -61,6 +82,22 @@ local function set_resp_header(tb, key, value, no_override)
+             error("invalid header value", 3)
+         end
+ 
++        if M1 then
++            local q = ffi.new("ngx_set_resp_header_t")
++            q.r = r
++            q.key_data = key
++            q.key_len = #key
++            q.is_nil = true
++            q.sval_len = 0
++            q.mvals_len = 0
++            q.override = 1
++            q.errmsg = errmsg
++
++            rc = C.ngx_http_lua_ffi_set_resp_header_m1(q)
++
++            goto results
++        end
++
+         rc = C.ngx_http_lua_ffi_set_resp_header(r, key, #key, true, nil, 0, nil,
+                                                 0, 1, errmsg)
+     else
+@@ -99,11 +136,32 @@ local function set_resp_header(tb, key, value, no_override)
+         end
+ 
+         local override_int = no_override and 0 or 1
++
++        if M1 then
++            local s = ffi.new("ngx_set_resp_header_t")
++            s.r = r
++            s.key_data = key
++            s.key_len = #key
++            s.is_nil = false
++            s.sval = sval
++            s.sval_len = sval_len
++            s.mvals = mvals
++            s.mvals_len = mvals_len
++            s.override = override_int
++            s.errmsg = errmsg
++
++            rc = C.ngx_http_lua_ffi_set_resp_header_m1(s)
++
++            goto results
++        end
++
+         rc = C.ngx_http_lua_ffi_set_resp_header(r, key, #key, false, sval,
+                                                 sval_len, mvals, mvals_len,
+                                                 override_int, errmsg)
+     end
+ 
++    ::results::
++
+     if rc == 0 or rc == FFI_DECLINED then
+         return
+     end
+-- 
+2.34.1
+


### PR DESCRIPTION
### Summary

This is related to:
https://github.com/Kong/kong/pull/8202

The C `open` is variadic and causes issues with M1. So one patch was included for that. The other patch is for pcall which seemed to be reasonable to include as well.

PS. I tried latest LuaJIT and OpenResty `master` branches as well, but they caused issues.