### PR TITLE
feat(dl): add --download-extract-only flag

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -5,6 +5,7 @@ set -e
 SCRIPT_PATH=
 PREFIX=
 DOWNLOAD_CACHE=work
+DOWNLOAD_ONLY=
 OPENRESTY_VER=
 OPENSSL_VER=
 BORINGSSL_VER=
@@ -101,6 +102,10 @@ main() {
       --add-module)
         NGINX_EXTRA_MODULES+=("--add-module=$2")
         shift 2
+        ;;
+      --donwload-extract-only)
+        DOWNLOAD_ONLY=1
+        shift 1
         ;;
       -h|--help)
         show_usage
@@ -209,6 +214,8 @@ main() {
 
         if [ ! -z ${OPENSSL_SHA+x} ]; then
           echo "$OPENSSL_SHA openssl-$OPENSSL_VER.tar.gz" | sha256sum -c -
+        else
+          notice "Downloaded: $(sha256sum "openssl-$OPENSSL_VER.tar.gz")"
         fi
         tar -xzf openssl-$OPENSSL_VER.tar.gz
       fi
@@ -224,8 +231,11 @@ main() {
         [[ $? != 0 ]] && err "Could not download BoringSSL"
         set -e
 
-        # -- check hash? --
-
+        if [ ! -z ${BORINGSSL_SHA+x} ]; then
+          echo "$BORINGSSL_SHA boringssl-${BORINGSSL_VER}.zip" | sha256sum -c -
+        else
+          notice "Downloaded: $(sha256sum "boringssl-${BORINGSSL_VER}.zip")"
+        fi
         unzip -q boringssl-${BORINGSSL_VER}.zip
       fi
     fi
@@ -247,6 +257,8 @@ main() {
         curl -sSLO https://openresty.org/download/openresty-$OPENRESTY_VER.tar.gz
         if [ ! -z ${OPENRESTY_SHA+x} ]; then
           echo "$OPENRESTY_SHA openresty-$OPENRESTY_VER.tar.gz" | sha256sum -c -
+        else
+          notice "Downloaded: $(sha256sum "openresty-$OPENRESTY_VER.tar.gz")"
         fi
         tar -xzf openresty-$OPENRESTY_VER.tar.gz
 
@@ -271,6 +283,8 @@ main() {
         curl -sSLO https://downloads.sourceforge.net/project/pcre/pcre/${PCRE_VER}/pcre-${PCRE_VER}.tar.gz
         if [ ! -z ${PCRE_SHA+x} ]; then
           echo "$PCRE_SHA pcre-${PCRE_VER}.tar.gz" | sha256sum -c -
+        else
+          notice "Downloaded: $(sha256sum "pcre-${PCRE_VER}.tar.gz")"
         fi
         tar -xzf pcre-${PCRE_VER}.tar.gz
       fi
@@ -295,6 +309,8 @@ main() {
           set -e
           if [ ! -z ${LUAROCKS_SHA+x} ]; then
             echo "$LUAROCKS_SHA luarocks-$LUAROCKS_VER.tar.gz" | sha256sum -c -
+          else
+            notice "Downloaded: $(sha256sum "luarocks-$LUAROCKS_VER.tar.gz")"
           fi
           tar -xzf luarocks-$LUAROCKS_VER.tar.gz
         fi
@@ -320,6 +336,11 @@ main() {
       popd
     fi
   popd
+
+  if [ ! -z "$DOWNLOAD_ONLY" ]; then
+    notice "Exiting early since --download-extract-only was specified"
+    exit 0
+  fi
 
   notice "Patching the components now..."
 


### PR DESCRIPTION
This adds a flag to the `openresty` build script entitled: `--download-extract-only`: the purpose of which is to seed the download cache with the various source archives this script collects, and exiting early to avoid also compiling those sources.
Subsequent runs of this script, assuming `--work`/`$DOWNLOAD_CACHE` is the same, will avoid re-download/extracting said files via the numerous `test -d` `if/then/fi` checks that already exist here.

Ideally, this would have been solely a `--download-only` flag but the current structure of the script doesn't lend itself to early termination/return (as it place entirely within a single `main()` function).