### PR TITLE
fix: adding openresty-build-tools/build folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ id_rsa.private
 kong_license.private
 *.deb
 *.rpm
+openresty-build-tools/build


### PR DESCRIPTION
Adding `openresty-build-tools/build` in `.gitignore`.