### PR TITLE
fix(lmdb) pass --resty-lmdb in build-openresty.sh

### DIFF
--- a/build-openresty.sh
+++ b/build-openresty.sh
@@ -8,7 +8,7 @@ touch $BUILD_OUTPUT
 
 dump_output() {
    echo Tailing the last 500 lines of output:
-   cat $BUILD_OUTPUT  
+   cat $BUILD_OUTPUT
 }
 error_handler() {
   echo ERROR: An error was encountered with the build.
@@ -39,6 +39,11 @@ then
   KONG_NGINX_MODULE="master"
 fi
 
+if [ -z "$RESTY_LMDB" ]
+then
+  RESTY_LMDB=0
+fi
+
 LUAROCKS_PREFIX=/usr/local \
 LUAROCKS_DESTDIR=/tmp/build \
 OPENRESTY_PREFIX=/usr/local/openresty \
@@ -51,6 +56,7 @@ EDITION=$EDITION \
 /tmp/openresty-build-tools/kong-ngx-build -p /tmp/build/usr/local \
 --openresty $RESTY_VERSION \
 --openssl $RESTY_OPENSSL_VERSION \
+--resty-lmdb $RESTY_LMDB \
 --luarocks $RESTY_LUAROCKS_VERSION \
 --kong-nginx-module $KONG_NGINX_MODULE \
 --pcre $RESTY_PCRE_VERSION \


### PR DESCRIPTION
Reasoning for this change: we need to be able to build lmdb directly
fron kong-build-tools Makefile.

Currently the process is:
* The Makefile initializes RESTY_LMDB with the contents of kong's
  .requirements file, or empty string otherwise
* `make build-kong` calls `make build-openresty`
* `make build-openresty` will call
  `docker build -f dockerfiles/Dockerfile.openresty`, passing
  `--build-arg RESTY_LMDB`
* The dockerfile copies `build-openresty.sh` & `openresty-build-tools`
* `build-openresty.sh` gets called inside the docker image
* It calls openresty-build-tools, but it never passes --resty-lmdb

At this point, the lmdb build is "broken": there is no way to build lmdb
from the kbt makefile.

This change should make it possible to build lmdb from any kong repo
that RESTY_LMDB set on the .requirements folder.
