### PR TITLE
fix(lmdb) make RESTY_LMDB build-time var into ENV

### DIFF
--- a/dockerfiles/Dockerfile.openresty
+++ b/dockerfiles/Dockerfile.openresty
@@ -79,6 +79,9 @@ LABEL resty_pcre_version="${RESTY_PCRE_VERSION}"
 ARG RESTY_LUAROCKS_VERSION=3.7.0
 LABEL resty_luarocks_version="${RESTY_LUAROCKS_VERSION}"
 
+ARG RESTY_LMDB=0
+LABEL resty_lmdb="${RESTY_LMDB}"
+
 COPY openresty-build-tools /tmp/openresty-build-tools
 COPY openresty-patches /tmp/openresty-patches
 COPY build-openresty.sh /tmp/build-openresty.sh


### PR DESCRIPTION
Related with #434

Further testing has proved that the value of RESTY_LMDB was still not
passed around properly from the initial value set by this repo's
Makefile when it arrived to `openresty-build-tools`

The culprint seems to be that `RESTY_LMDB` was passed as a built-time
variable to the intermediate Docker image via the `--build-arg` option,
but _built-time variables are only available during ... build time. They
are *not* available during the actual running of the image.

In order to make them available during run time they must be:
* Declared as ARG variables on the Dockerfile, with an optional default
  value if none was provided via --build-arg
* Used to initialize ENV variables
As shown on this PR.

Note that on this case the default value for the `ARG` is 0, so by default it
won't be built. But this value will always be overriden when building from the Makefile:
* If kong's .requirements file contains a `RESTY_LMDB entry`, its value will be
  passed via `--build-arg` to Dockerfile.openresty
* Otherwise the --build-arg value passed will be set `0`, deactivating
  lmdb
