### PR TITLE
feat(cache): the cache buster is one cause of why we have cache missed during a release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ else
 	DOCKER_COMMAND?=docker buildx build --push --platform="linux/amd64,linux/arm64"
 endif
 
-# Cache gets automatically busted every week. Set this to unique value to skip the cache
-CACHE_BUSTER?=`date +%V`
+# Set this to unique value to bust the cache
+CACHE_BUSTER?=0
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 TEST_SHA=$$(git log -1 --pretty=format:"%h" -- ${ROOT_DIR}/test/)${CACHE_BUSTER}
 


### PR DESCRIPTION
Kong dependency cache:

We need to invalidate cache if:
- specific parts of kong-build-tools changed. What those parts are is fairly large in scope and the repository doesn't change "that" often so let's invalidate if any of it changes
- if any dependency version changes. These are tracked in kong.git:/.requirements so invalidate anytime that file changes

We also require a cache per architecture and per distribution at a minimum in some cases we need a cache between versions of a specific distribution.

Looking at the last X builds the majority of our releases missed the cache because of the cache busting. The cache busting intention was to capture breaking changes that happen in the larger ecosystem that we might not be aware of because of the cache. To my knowledge that's only happened once -- the cost of not having a cache where we should doesn't justify this benefit

```
zero cache: ~7min
partially primed base cache only: ~5min30 (aka https://konghq.atlassian.net/browse/FT-2144)
fully primed remote cache: ~1m21sec
fully primed local cache: ~32sec
```