### PR TITLE
feat(openresty-patches) update mtls cosocket patches

### DIFF
--- a/openresty-patches/patches/1.19.9.1/lua-resty-core-0.1.22_01-cosocket-mtls.patch
+++ b/openresty-patches/patches/1.19.9.1/lua-resty-core-0.1.22_01-cosocket-mtls.patch
@@ -1,7 +1,7 @@
 From 4f0f4bf63d23a952179aaf810c10dfffc19ee835 Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Fri, 28 Jan 2022 20:54:30 +0800
-Subject: [PATCH 1/8] move tcp.lua into socket.lua
+Subject: [PATCH 1/9] move tcp.lua into socket.lua
 
 ---
  lib/resty/core/socket.lua | 136 +++++++++++++++++++++++++++++++++++++-
@@ -192,7 +192,7 @@ index 1a504ec..cc0081e 100644
 From 4eab5793d741c739d9c5cfe14e0671c1d70fd6e5 Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Fri, 28 Jan 2022 21:37:45 +0800
-Subject: [PATCH 2/8] revert assert in sslhandshake
+Subject: [PATCH 2/9] revert assert in sslhandshake
 
 ---
  lib/resty/core/socket.lua | 5 +++++
@@ -235,7 +235,7 @@ index cc0081e..7c61d06 100644
 From 58de9a44c89f07eda98bb7fd978a9e04a244d2f2 Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Fri, 28 Jan 2022 21:45:42 +0800
-Subject: [PATCH 3/8] rename ffi_string to ffi_str
+Subject: [PATCH 3/9] rename ffi_string to ffi_str
 
 ---
  lib/resty/core/socket.lua | 10 +++++-----
@@ -292,7 +292,7 @@ index 7c61d06..14457da 100644
 From ff138619432bda6b9bd4f37403c12600a4739e47 Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Sat, 29 Jan 2022 07:23:16 +0800
-Subject: [PATCH 4/8] minor style fix
+Subject: [PATCH 4/9] minor style fix
 
 ---
  lib/resty/core/socket.lua | 15 +++++++++------
@@ -343,7 +343,7 @@ index 14457da..3c882af 100644
 From a843a258987efba49f0b6979389f75ee32c2150c Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Sat, 29 Jan 2022 07:28:41 +0800
-Subject: [PATCH 5/8] rename self to cosocket
+Subject: [PATCH 5/9] rename self to cosocket
 
 ---
  lib/resty/core/socket.lua | 18 +++++++++---------
@@ -413,7 +413,7 @@ index 3c882af..374d583 100644
 From db95a049a019ff6f0d3b4e550412e40c25dda41f Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Sat, 29 Jan 2022 07:35:04 +0800
-Subject: [PATCH 6/8] use get_tcp_socket() in sslhandshake
+Subject: [PATCH 6/9] use get_tcp_socket() in sslhandshake
 
 ---
  lib/resty/core/socket.lua | 2 +-
@@ -439,7 +439,7 @@ index 374d583..ecff453 100644
 From 6767f0c2e8a73fd1a09d727431bed457c5cac4c0 Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Sat, 29 Jan 2022 08:58:52 +0800
-Subject: [PATCH 7/8] fix arguments check in sslhandshake
+Subject: [PATCH 7/9] fix arguments check in sslhandshake
 
 ---
  lib/resty/core/socket.lua | 2 +-
@@ -465,7 +465,7 @@ index ecff453..15e3065 100644
 From 4eeddcd2114d0097e4b9cb11f2f93d30c70d573e Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Mon, 7 Feb 2022 10:59:35 +0800
-Subject: [PATCH 8/8] setclientcert return err
+Subject: [PATCH 8/9] setclientcert return err
 
 ---
  lib/resty/core/socket.lua | 13 ++++++++-----
@@ -505,6 +505,59 @@ index 15e3065..879d678 100644
      cosocket.client_pkey = pkey
 +
 +    return true
+ end
+ 
+ 
+-- 
+2.32.0 (Apple Git-132)
+
+
+From fead2a28f409117ad1b6c98d02edb6a38a64fde0 Mon Sep 17 00:00:00 2001
+From: James Hurst <james@reel.audio>
+Date: Wed, 9 Feb 2022 16:05:11 +0000
+Subject: [PATCH 9/9] fix(socket) add temporary backwards compatability for
+ tlshandshake
+
+---
+ lib/resty/core/socket.lua | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket.lua b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+index 879d678..448bf36 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/socket.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+@@ -253,12 +253,34 @@ local function sslhandshake(cosocket, reused_session, server_name, ssl_verify,
+ end
+ 
+ 
++-- Temporary patch for backwards compatablity with existing Kong tech debt
++local function tlshandshake(cosocket, options)
++    local options = options or {}
++
++    if options.client_cert then
++        local ok, err = cosocket:setclientcert(options.client_cert, options.client_priv_key)
++        if not ok then
++            return nil, err
++        end
++    end
++
++    return sslhandshake(
++        cosocket,
++        options.reused_session,
++        options.server_name,
++        options.ssl_verify,
++        options.ocsp_status_req
++    )
++end
++
++
+ do
+     local method_table = registry.__tcp_cosocket_mt
+     method_table.getoption = getoption
+     method_table.setoption = setoption
+     method_table.setclientcert = setclientcert
+     method_table.sslhandshake  = sslhandshake
++    method_table.tlshandshake  = tlshandshake
  end
  
  

--- a/openresty-patches/patches/1.19.9.1/lua-resty-core-0.1.22_01-cosocket-mtls.patch
+++ b/openresty-patches/patches/1.19.9.1/lua-resty-core-0.1.22_01-cosocket-mtls.patch
@@ -1,148 +1,103 @@
-From ddf9dac29e0dd8376e51b369710e42c948e9d959 Mon Sep 17 00:00:00 2001
-From: Datong Sun <datong.sun@konghq.com>
-Date: Wed, 18 Sep 2019 16:41:56 -0700
-Subject: =?UTF-8?q?feature:=20implement=20the=20`tcpsock:tlshandshake`=20a?=
- =?UTF-8?q?nd=20`tcpsock:sslhandshake`=0Afunctions=20using=20FFI.?=
+From 4f0f4bf63d23a952179aaf810c10dfffc19ee835 Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Fri, 28 Jan 2022 20:54:30 +0800
+Subject: [PATCH 1/7] move tcp.lua into socket.lua
 
 ---
- lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua | 172 ++++++++++++++++++++++++++++++++++
- 2 files changed, 173 insertions(+)
- create mode 100644 lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
+ lib/resty/core/socket.lua | 136 +++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 133 insertions(+), 3 deletions(-)
 
-diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-new file mode 100644
-index 0000000..fe81de5
---- /dev/null
-+++ b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-@@ -0,0 +1,172 @@
-+local ffi = require("ffi")
-+local base = require("resty.core.base")
-+
-+local C = ffi.C
-+local ffi_string = ffi.string
-+local ffi_gc = ffi.gc
-+local FFI_ERROR = base.FFI_ERROR
-+local FFI_DONE = base.FFI_DONE
-+local FFI_OK = base.FFI_OK
-+local FFI_AGAIN = base.FFI_AGAIN
-+local get_request = base.get_request
-+local error = error
-+local assert = assert
-+local getmetatable = getmetatable
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket.lua b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+index 1a504ec..cc0081e 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/socket.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+@@ -6,13 +6,21 @@ local ffi = require 'ffi'
+ 
+ local error = error
+ local tonumber = tonumber
++local tostring = tostring
 +local type = type
 +local select = select
+ local registry = debug.getregistry()
++
++local C = ffi.C
+ local ffi_new = ffi.new
+ local ffi_string = ffi.string
+-local C = ffi.C
++local ffi_gc = ffi.gc
++
+ local get_string_buf = base.get_string_buf
+ local get_size_ptr = base.get_size_ptr
+-local tostring = tostring
++local get_request = base.get_request
++
 +local co_yield = coroutine._yield
-+local table_new = require("table.new")
-+local table_clear = require("table.clear")
+ 
+ 
+ local option_index = {
+@@ -35,15 +43,29 @@ ngx_http_lua_ffi_socket_tcp_getoption(ngx_http_lua_socket_tcp_upstream_t *u,
+ int
+ ngx_http_lua_ffi_socket_tcp_setoption(ngx_http_lua_socket_tcp_upstream_t *u,
+     int opt, int val, unsigned char *err, size_t *errlen);
 +
-+if not pcall(ffi.typeof, "ngx_ssl_session_t") then
-+    ffi.cdef[[
-+        typedef struct SSL_SESSION ngx_ssl_session_t;
-+    ]]
-+end
-+
-+ffi.cdef[[
-+typedef struct ngx_http_lua_socket_tcp_upstream_s ngx_http_lua_socket_tcp_upstream_t;
-+
-+int ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
-+    ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t *sess,
++int ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
++    ngx_http_lua_socket_tcp_upstream_t *u, void *sess,
 +    int enable_session_reuse, ngx_str_t *server_name, int verify,
-+    int ocsp_status_req, char **errmsg);
-+int ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(ngx_http_request_t *r,
-+    ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t **sess,
-+    char **errmsg, int *openssl_error_code);
-+void ngx_http_lua_ffi_tls_free_session(ngx_ssl_session_t *sess);
-+]]
++    int ocsp_status_req, void *chain, void *pkey, char **errmsg);
 +
++int ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(ngx_http_request_t *r,
++    ngx_http_lua_socket_tcp_upstream_t *u, void **sess, char **errmsg,
++    int *openssl_error_code);
 +
-+local SOCKET_CTX_INDEX = 1
-+
-+
++void ngx_http_lua_ffi_ssl_free_session(void *sess);
+ ]]
+ 
+ 
+ local output_value_buf = ffi_new("int[1]")
+ local FFI_OK = base.FFI_OK
++local FFI_ERROR = base.FFI_ERROR
++local FFI_DONE = base.FFI_DONE
++local FFI_AGAIN = base.FFI_AGAIN
++local FFI_NO_REQ_CTX = base.FFI_NO_REQ_CTX
+ local SOCKET_CTX_INDEX = 1
+ local ERR_BUF_SIZE = 4096
+ 
+-
+ local function get_tcp_socket(cosocket)
+     local tcp_socket = cosocket[SOCKET_CTX_INDEX]
+     if not tcp_socket then
+@@ -114,10 +136,118 @@ local function setoption(cosocket, option, value)
+ end
+ 
+ 
 +local errmsg = base.get_errmsg_ptr()
-+local session_ptr = ffi.new("ngx_ssl_session_t *[1]")
-+local server_name_str = ffi.new("ngx_str_t[1]")
-+local openssl_error_code = ffi.new("int[1]")
-+local cached_options = table_new(0, 4)
++local session_ptr = ffi_new("void *[1]")
++local server_name_str = ffi_new("ngx_str_t[1]")
++local openssl_error_code = ffi_new("int[1]")
 +
 +
-+local function tlshandshake(self, options)
-+    if not options then
-+        table_clear(cached_options)
-+        options = cached_options
-+
-+    elseif type(options) ~= "table" then
-+        error("bad options table type")
++local function setclientcert(self, cert, pkey)
++    if not cert and not pkey then
++        self.client_cert = nil
++        self.client_pkey = nil
++        return
 +    end
 +
-+    local r = get_request()
-+
-+    if not r then
-+        error("no request found")
++    if not cert or not pkey then
++        error("client certificate must be supplied with corresponding " ..
++              "private key", 2)
 +    end
 +
-+    local reused_session = options.reused_session
-+    session_ptr[0] = type(reused_session) == "cdata" and reused_session or nil
-+
-+    if options.server_name then
-+        server_name_str[0].data = options.server_name
-+        server_name_str[0].len = #options.server_name
-+
-+    else
-+        server_name_str[0].data = nil
-+        server_name_str[0].len = 0
++    if type(cert) ~= "cdata" then
++        error("bad client cert type", 2)
 +    end
 +
-+    local rc =
-+        C.ngx_http_lua_ffi_socket_tcp_tlshandshake(r, self[SOCKET_CTX_INDEX],
-+                                                   session_ptr[0],
-+                                                   reused_session ~= false,
-+                                                   server_name_str,
-+                                                   options.verify and 1 or 0,
-+                                                   options.ocsp_status_req
-+                                                       and 1 or 0,
-+                                                   errmsg)
-+
-+::again::
-+
-+    if rc == FFI_ERROR then
-+        if openssl_error_code[0] ~= 0 then
-+            return nil, openssl_error_code[0] .. ": " .. ffi_string(errmsg[0])
-+        end
-+
-+        return nil, ffi_string(errmsg[0])
++    if type(pkey) ~= "cdata" then
++        error("bad client pkey type", 2)
 +    end
 +
-+    if rc == FFI_DONE then
-+        return options.reused_session
-+    end
-+
-+    if rc == FFI_OK then
-+        if options.reused_session == false then
-+            return true
-+        end
-+
-+        rc = C.ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(r,
-+            self[SOCKET_CTX_INDEX], session_ptr, errmsg, openssl_error_code)
-+
-+        assert(rc == FFI_OK)
-+
-+        if session_ptr[0] == nil then
-+            return session_ptr[0]
-+        end
-+
-+        return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_tls_free_session)
-+    end
-+
-+    assert(rc == FFI_AGAIN)
-+
-+    co_yield()
-+
-+    rc = C.ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(r,
-+        self[SOCKET_CTX_INDEX], session_ptr, errmsg, openssl_error_code)
-+
-+    assert(rc == FFI_OK or rc  == FFI_ERROR)
-+
-+    goto again
++    self.client_cert = cert
++    self.client_pkey = pkey
 +end
 +
 +
@@ -151,295 +106,358 @@ index 0000000..fe81de5
 +
 +    local n = select("#", ...)
 +    if not self or n > 1 then
-+        error("ngx.socket sslhandshake: expecting 1 ~ 5 "
-+              .. "arguments (including the object), but seen " .. n)
++        error("ngx.socket sslhandshake: expecting 1 ~ 5 arguments " ..
++              "(including the object), but seen " .. (5 + n))
 +    end
 +
-+    cached_options.reused_session = reused_session
-+    cached_options.server_name = server_name
-+    cached_options.verify = ssl_verify
-+    cached_options.ocsp_status_req = send_status_req
-+
-+    local res, err = tlshandshake(self, cached_options)
-+    table_clear(cached_options)
-+
-+    return res, err
-+end
-+
-+
-+do
-+    local old_socket_tcp = ngx.socket.tcp
-+
-+    function ngx.socket.tcp()
-+        local sock = old_socket_tcp()
-+        local mt = getmetatable(sock)
-+
-+        mt.tlshandshake = tlshandshake
-+        mt.sslhandshake = sslhandshake
-+
-+        ngx.socket.tcp = old_socket_tcp
-+
-+        return sock
++    local r = get_request()
++    if not r then
++        error("no request found", 2)
 +    end
-+end
 +
++    session_ptr[0] = type(reused_session) == "cdata" and reused_session or nil
 +
-+return {
-+    version = base.version
-+}
---
-2.20.1
-
-
-From 1b73826f746a9dd04f60c560d47e778fbec2c2d9 Mon Sep 17 00:00:00 2001
-From: Datong Sun <datong.sun@konghq.com>
-Date: Wed, 18 Sep 2019 16:55:05 -0700
-Subject: change: better error when request context couldn't be found.
-
----
- lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua | 5 +++++
- 1 file changed, 5 insertions(+)
-
-diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-index fe81de5..e18f40e 100644
---- a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-+++ b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-@@ -8,6 +8,7 @@ local FFI_ERROR = base.FFI_ERROR
- local FFI_DONE = base.FFI_DONE
- local FFI_OK = base.FFI_OK
- local FFI_AGAIN = base.FFI_AGAIN
-+local FFI_NO_REQ_CTX = base.FFI_NO_REQ_CTX
- local get_request = base.get_request
- local error = error
- local assert = assert
-@@ -85,6 +86,10 @@ local function tlshandshake(self, options)
-                                                        and 1 or 0,
-                                                    errmsg)
-
++    if server_name then
++        server_name_str[0].data = server_name
++        server_name_str[0].len = #server_name
++
++    else
++        server_name_str[0].data = nil
++        server_name_str[0].len = 0
++    end
++
++    local u = self[SOCKET_CTX_INDEX]
++
++    local rc = C.ngx_http_lua_ffi_socket_tcp_sslhandshake(r, u,
++                   session_ptr[0],
++                   reused_session ~= false,
++                   server_name_str,
++                   ssl_verify and 1 or 0,
++                   send_status_req and 1 or 0,
++                   self.client_cert, self.client_pkey, errmsg)
++
 +    if rc == FFI_NO_REQ_CTX then
 +        error("no request ctx found", 2)
 +    end
 +
- ::again::
++    while true do
++        if rc == FFI_ERROR then
++            if openssl_error_code[0] ~= 0 then
++                return nil, openssl_error_code[0] .. ": " .. ffi_string(errmsg[0])
++            end
++
++            return nil, ffi_string(errmsg[0])
++        end
++
++        if rc == FFI_DONE then
++            return reused_session
++        end
++
++        if rc == FFI_OK then
++            if reused_session == false then
++                return true
++            end
++
++            rc = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
++                     session_ptr, errmsg, openssl_error_code)
++
++            if session_ptr[0] == nil then
++                return nil
++            end
++
++            return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_ssl_free_session)
++        end
++
++        co_yield()
++
++        rc = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
++                 session_ptr, errmsg, openssl_error_code)
++    end
++end
++
++
+ do
+     local method_table = registry.__tcp_cosocket_mt
+     method_table.getoption = getoption
+     method_table.setoption = setoption
++    method_table.setclientcert = setclientcert
++    method_table.sslhandshake  = sslhandshake
+ end
+ 
+ 
+-- 
+2.32.0 (Apple Git-132)
 
-     if rc == FFI_ERROR then
---
-2.20.1
 
-
-From 0fea325cd7d6ca479afbc8abbc297b4a046bc8c3 Mon Sep 17 00:00:00 2001
-From: Datong Sun <datong.sun@konghq.com>
-Date: Wed, 18 Sep 2019 17:23:08 -0700
-Subject: cosocket: added client certificate support with TLS handshake.
+From 4eab5793d741c739d9c5cfe14e0671c1d70fd6e5 Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Fri, 28 Jan 2022 21:37:45 +0800
+Subject: [PATCH 2/7] revert assert in sslhandshake
 
 ---
- lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua | 34 +++++++++++++++++++++++-----------
- 1 file changed, 23 insertions(+), 11 deletions(-)
+ lib/resty/core/socket.lua | 5 +++++
+ 1 file changed, 5 insertions(+)
 
-diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-index e18f40e..ed45c8a 100644
---- a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-+++ b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-@@ -19,23 +19,18 @@ local co_yield = coroutine._yield
- local table_new = require("table.new")
- local table_clear = require("table.clear")
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket.lua b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+index cc0081e..7c61d06 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/socket.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+@@ -5,6 +5,7 @@ local ffi = require 'ffi'
+ 
+ 
+ local error = error
++local assert = assert
+ local tonumber = tonumber
+ local tostring = tostring
+ local type = type
+@@ -227,6 +228,8 @@ local function sslhandshake(self, reused_session, server_name, ssl_verify,
+             rc = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
+                      session_ptr, errmsg, openssl_error_code)
+ 
++            assert(rc == FFI_OK)
++
+             if session_ptr[0] == nil then
+                 return nil
+             end
+@@ -234,6 +237,8 @@ local function sslhandshake(self, reused_session, server_name, ssl_verify,
+             return ffi_gc(session_ptr[0], C.ngx_http_lua_ffi_ssl_free_session)
+         end
+ 
++        assert(rc == FFI_AGAIN)
++
+         co_yield()
+ 
+         rc = C.ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(r, u,
+-- 
+2.32.0 (Apple Git-132)
 
--if not pcall(ffi.typeof, "ngx_ssl_session_t") then
--    ffi.cdef[[
--        typedef struct SSL_SESSION ngx_ssl_session_t;
--    ]]
--end
--
- ffi.cdef[[
- typedef struct ngx_http_lua_socket_tcp_upstream_s ngx_http_lua_socket_tcp_upstream_t;
 
- int ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
--    ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t *sess,
-+    ngx_http_lua_socket_tcp_upstream_t *u, void *sess,
+From 58de9a44c89f07eda98bb7fd978a9e04a244d2f2 Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Fri, 28 Jan 2022 21:45:42 +0800
+Subject: [PATCH 3/7] rename ffi_string to ffi_str
+
+---
+ lib/resty/core/socket.lua | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket.lua b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+index 7c61d06..14457da 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/socket.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+@@ -14,7 +14,7 @@ local registry = debug.getregistry()
+ 
+ local C = ffi.C
+ local ffi_new = ffi.new
+-local ffi_string = ffi.string
++local ffi_str = ffi.string
+ local ffi_gc = ffi.gc
+ 
+ local get_string_buf = base.get_string_buf
+@@ -98,7 +98,7 @@ local function getoption(cosocket, option)
+                                                        err,
+                                                        errlen)
+     if rc ~= FFI_OK then
+-        return nil, ffi_string(err, errlen[0])
++        return nil, ffi_str(err, errlen[0])
+     end
+ 
+     return tonumber(output_value_buf[0])
+@@ -130,7 +130,7 @@ local function setoption(cosocket, option, value)
+                                                        err,
+                                                        errlen)
+     if rc ~= FFI_OK then
+-        return nil, ffi_string(err, errlen[0])
++        return nil, ffi_str(err, errlen[0])
+     end
+ 
+     return true
+@@ -210,10 +210,10 @@ local function sslhandshake(self, reused_session, server_name, ssl_verify,
+     while true do
+         if rc == FFI_ERROR then
+             if openssl_error_code[0] ~= 0 then
+-                return nil, openssl_error_code[0] .. ": " .. ffi_string(errmsg[0])
++                return nil, openssl_error_code[0] .. ": " .. ffi_str(errmsg[0])
+             end
+ 
+-            return nil, ffi_string(errmsg[0])
++            return nil, ffi_str(errmsg[0])
+         end
+ 
+         if rc == FFI_DONE then
+-- 
+2.32.0 (Apple Git-132)
+
+
+From ff138619432bda6b9bd4f37403c12600a4739e47 Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Sat, 29 Jan 2022 07:23:16 +0800
+Subject: [PATCH 4/7] minor style fix
+
+---
+ lib/resty/core/socket.lua | 15 +++++++++------
+ 1 file changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket.lua b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+index 14457da..3c882af 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/socket.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+@@ -1,7 +1,7 @@
+ local base = require "resty.core.base"
+-base.allows_subsystem('http')
+-local debug = require 'debug'
+-local ffi = require 'ffi'
++base.allows_subsystem("http")
++local debug = require "debug"
++local ffi = require "ffi"
+ 
+ 
+ local error = error
+@@ -45,16 +45,19 @@ int
+ ngx_http_lua_ffi_socket_tcp_setoption(ngx_http_lua_socket_tcp_upstream_t *u,
+     int opt, int val, unsigned char *err, size_t *errlen);
+ 
+-int ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
++int
++ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, void *sess,
      int enable_session_reuse, ngx_str_t *server_name, int verify,
--    int ocsp_status_req, char **errmsg);
-+    int ocsp_status_req, void *chain, void *pkey,
-+    char **errmsg);
- int ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(ngx_http_request_t *r,
--    ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t **sess,
-+    ngx_http_lua_socket_tcp_upstream_t *u, void **sess,
-     char **errmsg, int *openssl_error_code);
--void ngx_http_lua_ffi_tls_free_session(ngx_ssl_session_t *sess);
-+void ngx_http_lua_ffi_tls_free_session(void *sess);
+     int ocsp_status_req, void *chain, void *pkey, char **errmsg);
+ 
+-int ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(ngx_http_request_t *r,
++int
++ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, void **sess, char **errmsg,
+     int *openssl_error_code);
+ 
+-void ngx_http_lua_ffi_ssl_free_session(void *sess);
++void
++ngx_http_lua_ffi_ssl_free_session(void *sess);
  ]]
+ 
+ 
+-- 
+2.32.0 (Apple Git-132)
 
 
-@@ -43,7 +38,7 @@ local SOCKET_CTX_INDEX = 1
+From a843a258987efba49f0b6979389f75ee32c2150c Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Sat, 29 Jan 2022 07:28:41 +0800
+Subject: [PATCH 5/7] rename self to cosocket
 
+---
+ lib/resty/core/socket.lua | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
 
- local errmsg = base.get_errmsg_ptr()
--local session_ptr = ffi.new("ngx_ssl_session_t *[1]")
-+local session_ptr = ffi.new("void *[1]")
- local server_name_str = ffi.new("ngx_str_t[1]")
- local openssl_error_code = ffi.new("int[1]")
- local cached_options = table_new(0, 4)
-@@ -76,6 +71,21 @@ local function tlshandshake(self, options)
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket.lua b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+index 3c882af..374d583 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/socket.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+@@ -146,10 +146,10 @@ local server_name_str = ffi_new("ngx_str_t[1]")
+ local openssl_error_code = ffi_new("int[1]")
+ 
+ 
+-local function setclientcert(self, cert, pkey)
++local function setclientcert(cosocket, cert, pkey)
+     if not cert and not pkey then
+-        self.client_cert = nil
+-        self.client_pkey = nil
++        cosocket.client_cert = nil
++        cosocket.client_pkey = nil
+         return
+     end
+ 
+@@ -166,16 +166,16 @@ local function setclientcert(self, cert, pkey)
+         error("bad client pkey type", 2)
+     end
+ 
+-    self.client_cert = cert
+-    self.client_pkey = pkey
++    cosocket.client_cert = cert
++    cosocket.client_pkey = pkey
+ end
+ 
+ 
+-local function sslhandshake(self, reused_session, server_name, ssl_verify,
++local function sslhandshake(cosocket, reused_session, server_name, ssl_verify,
+     send_status_req, ...)
+ 
+     local n = select("#", ...)
+-    if not self or n > 1 then
++    if not cosocket or n > 1 then
+         error("ngx.socket sslhandshake: expecting 1 ~ 5 arguments " ..
+               "(including the object), but seen " .. (5 + n))
+     end
+@@ -196,7 +196,7 @@ local function sslhandshake(self, reused_session, server_name, ssl_verify,
          server_name_str[0].len = 0
      end
-
-+    local client_cert = options.client_cert
-+    local client_priv_key = options.client_priv_key
-+    if client_cert then
-+        if not client_priv_key then
-+            error("client certificate supplied without "
-+                  .. "corresponding private key", 2)
-+        end
-+
-+        if type(client_cert) ~= "cdata"
-+           or type(client_priv_key) ~= "cdata"
-+        then
-+            error("wrong type of client certificate or private key supplied", 2)
-+        end
-+    end
-+
-     local rc =
-         C.ngx_http_lua_ffi_socket_tcp_tlshandshake(r, self[SOCKET_CTX_INDEX],
-                                                    session_ptr[0],
-@@ -84,6 +94,8 @@ local function tlshandshake(self, options)
-                                                    options.verify and 1 or 0,
-                                                    options.ocsp_status_req
-                                                        and 1 or 0,
-+                                                   client_cert,
-+                                                   client_priv_key,
-                                                    errmsg)
-
+ 
+-    local u = self[SOCKET_CTX_INDEX]
++    local u = cosocket[SOCKET_CTX_INDEX]
+ 
+     local rc = C.ngx_http_lua_ffi_socket_tcp_sslhandshake(r, u,
+                    session_ptr[0],
+@@ -204,7 +204,7 @@ local function sslhandshake(self, reused_session, server_name, ssl_verify,
+                    server_name_str,
+                    ssl_verify and 1 or 0,
+                    send_status_req and 1 or 0,
+-                   self.client_cert, self.client_pkey, errmsg)
++                   cosocket.client_cert, cosocket.client_pkey, errmsg)
+ 
      if rc == FFI_NO_REQ_CTX then
---
-2.20.1
+         error("no request ctx found", 2)
+-- 
+2.32.0 (Apple Git-132)
 
 
-From 3ed719e95bc9a0fd1a768c6ead1ca0b8b777905a Mon Sep 17 00:00:00 2001
-From: Datong Sun <datong.sun@konghq.com>
-Date: Wed, 18 Sep 2019 17:29:56 -0700
-Subject: style: fixed long line.
-
----
- lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua | 3 ++-
- 1 file changed, 2 insertions(+), 1 deletion(-)
-
-diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-index ed45c8a..a867c73 100644
---- a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-+++ b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-@@ -20,7 +20,8 @@ local table_new = require("table.new")
- local table_clear = require("table.clear")
-
- ffi.cdef[[
--typedef struct ngx_http_lua_socket_tcp_upstream_s ngx_http_lua_socket_tcp_upstream_t;
-+typedef struct ngx_http_lua_socket_tcp_upstream_s
-+    ngx_http_lua_socket_tcp_upstream_t;
-
- int ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
-     ngx_http_lua_socket_tcp_upstream_t *u, void *sess,
---
-2.20.1
-
-
-From 036a7f9b431c7d00fb905533a8f57c7e93f8e0a2 Mon Sep 17 00:00:00 2001
-From: Datong Sun <datong.sun@konghq.com>
-Date: Tue, 24 Sep 2019 16:10:13 -0700
-Subject: =?UTF-8?q?fix:=20transparently=20propagate=20error=20message=20wh?=
- =?UTF-8?q?en=20monkey=20patching=20TCP=0Asocket=20metatable.?=
+From db95a049a019ff6f0d3b4e550412e40c25dda41f Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Sat, 29 Jan 2022 07:35:04 +0800
+Subject: [PATCH 6/7] use get_tcp_socket() in sslhandshake
 
 ---
- lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua | 7 ++++++-
- 1 file changed, 6 insertions(+), 1 deletion(-)
+ lib/resty/core/socket.lua | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-index a867c73..a4f4eee 100644
---- a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-+++ b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-@@ -14,6 +14,7 @@ local error = error
- local assert = assert
- local getmetatable = getmetatable
- local type = type
-+local pcall = pcall
- local select = select
- local co_yield = coroutine._yield
- local table_new = require("table.new")
-@@ -172,7 +173,11 @@ do
-     local old_socket_tcp = ngx.socket.tcp
-
-     function ngx.socket.tcp()
--        local sock = old_socket_tcp()
-+        local ok, sock = pcall(old_socket_tcp)
-+        if not ok then
-+            error(sock, 2)
-+        end
-+
-         local mt = getmetatable(sock)
-
-         mt.tlshandshake = tlshandshake
---
-2.20.1
-
-
-From 75251e09f9950261ce7e587950907ff2982b2e51 Mon Sep 17 00:00:00 2001
-From: Datong Sun <datong.sun@konghq.com>
-Date: Mon, 28 Oct 2019 14:13:08 -0700
-Subject: load resty.core.socket_tcp to monkypatch the socket metatable
-
----
- lua-resty-core-0.1.22/lib/resty/core.lua | 1 +
- 1 file changed, 1 insertion(+)
-
-diff --git a/lua-resty-core-0.1.19/lib/resty/core.lua b/lua-resty-core-0.1.19/lib/resty/core.lua
-index 57c9d17..7e8aca4 100644
---- a/lua-resty-core-0.1.22/lib/resty/core.lua
-+++ b/lua-resty-core-0.1.22/lib/resty/core.lua
-@@ -20,6 +20,7 @@ if subsystem == 'http' then
-     require "resty.core.phase"
-     require "resty.core.ndk"
-     require "resty.core.socket"
-+    require "resty.core.socket_tcp"
- end
-
-
---
-2.20.1
-
-
-From 8d4d81b2fbfac93b270ef70f6441f0d1c70d999e Mon Sep 17 00:00:00 2001
-From: Datong Sun <datong.sun@konghq.com>
-Date: Thu, 5 Dec 2019 14:28:24 -0800
-Subject: [PATCH] do not change metatable to avoid conflicts with possible
- other monkypatches on `ngx.socket.tcp`
-
----
- lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua | 9 ++-------
- 1 file changed, 2 insertions(+), 7 deletions(-)
-
-diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-index a4f4eee..4cd2d77 100644
---- a/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-+++ b/lua-resty-core-0.1.22/lib/resty/core/socket_tcp.lua
-@@ -12,7 +12,6 @@ local FFI_NO_REQ_CTX = base.FFI_NO_REQ_CTX
- local get_request = base.get_request
- local error = error
- local assert = assert
--local getmetatable = getmetatable
- local type = type
- local pcall = pcall
- local select = select
-@@ -178,12 +177,8 @@ do
-             error(sock, 2)
-         end
-
--        local mt = getmetatable(sock)
--
--        mt.tlshandshake = tlshandshake
--        mt.sslhandshake = sslhandshake
--
--        ngx.socket.tcp = old_socket_tcp
-+        sock.tlshandshake = tlshandshake
-+        sock.sslhandshake = sslhandshake
-
-         return sock
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket.lua b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+index 374d583..ecff453 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/socket.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+@@ -196,7 +196,7 @@ local function sslhandshake(cosocket, reused_session, server_name, ssl_verify,
+         server_name_str[0].len = 0
      end
---
-2.20.1
+ 
+-    local u = cosocket[SOCKET_CTX_INDEX]
++    local u = get_tcp_socket(cosocket)
+ 
+     local rc = C.ngx_http_lua_ffi_socket_tcp_sslhandshake(r, u,
+                    session_ptr[0],
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 6767f0c2e8a73fd1a09d727431bed457c5cac4c0 Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Sat, 29 Jan 2022 08:58:52 +0800
+Subject: [PATCH 7/7] fix arguments check in sslhandshake
+
+---
+ lib/resty/core/socket.lua | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket.lua b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+index ecff453..15e3065 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/socket.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+@@ -177,7 +177,7 @@ local function sslhandshake(cosocket, reused_session, server_name, ssl_verify,
+     local n = select("#", ...)
+     if not cosocket or n > 1 then
+         error("ngx.socket sslhandshake: expecting 1 ~ 5 arguments " ..
+-              "(including the object), but seen " .. (5 + n))
++              "(including the object), but seen " .. (cosocket and 5 + n or 0))
+     end
+ 
+     local r = get_request()
+-- 
+2.32.0 (Apple Git-132)
+

--- a/openresty-patches/patches/1.19.9.1/lua-resty-core-0.1.22_01-cosocket-mtls.patch
+++ b/openresty-patches/patches/1.19.9.1/lua-resty-core-0.1.22_01-cosocket-mtls.patch
@@ -1,7 +1,7 @@
 From 4f0f4bf63d23a952179aaf810c10dfffc19ee835 Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Fri, 28 Jan 2022 20:54:30 +0800
-Subject: [PATCH 1/7] move tcp.lua into socket.lua
+Subject: [PATCH 1/8] move tcp.lua into socket.lua
 
 ---
  lib/resty/core/socket.lua | 136 +++++++++++++++++++++++++++++++++++++-
@@ -192,7 +192,7 @@ index 1a504ec..cc0081e 100644
 From 4eab5793d741c739d9c5cfe14e0671c1d70fd6e5 Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Fri, 28 Jan 2022 21:37:45 +0800
-Subject: [PATCH 2/7] revert assert in sslhandshake
+Subject: [PATCH 2/8] revert assert in sslhandshake
 
 ---
  lib/resty/core/socket.lua | 5 +++++
@@ -235,7 +235,7 @@ index cc0081e..7c61d06 100644
 From 58de9a44c89f07eda98bb7fd978a9e04a244d2f2 Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Fri, 28 Jan 2022 21:45:42 +0800
-Subject: [PATCH 3/7] rename ffi_string to ffi_str
+Subject: [PATCH 3/8] rename ffi_string to ffi_str
 
 ---
  lib/resty/core/socket.lua | 10 +++++-----
@@ -292,7 +292,7 @@ index 7c61d06..14457da 100644
 From ff138619432bda6b9bd4f37403c12600a4739e47 Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Sat, 29 Jan 2022 07:23:16 +0800
-Subject: [PATCH 4/7] minor style fix
+Subject: [PATCH 4/8] minor style fix
 
 ---
  lib/resty/core/socket.lua | 15 +++++++++------
@@ -343,7 +343,7 @@ index 14457da..3c882af 100644
 From a843a258987efba49f0b6979389f75ee32c2150c Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Sat, 29 Jan 2022 07:28:41 +0800
-Subject: [PATCH 5/7] rename self to cosocket
+Subject: [PATCH 5/8] rename self to cosocket
 
 ---
  lib/resty/core/socket.lua | 18 +++++++++---------
@@ -413,7 +413,7 @@ index 3c882af..374d583 100644
 From db95a049a019ff6f0d3b4e550412e40c25dda41f Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Sat, 29 Jan 2022 07:35:04 +0800
-Subject: [PATCH 6/7] use get_tcp_socket() in sslhandshake
+Subject: [PATCH 6/8] use get_tcp_socket() in sslhandshake
 
 ---
  lib/resty/core/socket.lua | 2 +-
@@ -439,7 +439,7 @@ index 374d583..ecff453 100644
 From 6767f0c2e8a73fd1a09d727431bed457c5cac4c0 Mon Sep 17 00:00:00 2001
 From: chronolaw <chrono_cpp@me.com>
 Date: Sat, 29 Jan 2022 08:58:52 +0800
-Subject: [PATCH 7/7] fix arguments check in sslhandshake
+Subject: [PATCH 7/8] fix arguments check in sslhandshake
 
 ---
  lib/resty/core/socket.lua | 2 +-
@@ -458,6 +458,56 @@ index ecff453..15e3065 100644
      end
  
      local r = get_request()
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 4eeddcd2114d0097e4b9cb11f2f93d30c70d573e Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Mon, 7 Feb 2022 10:59:35 +0800
+Subject: [PATCH 8/8] setclientcert return err
+
+---
+ lib/resty/core/socket.lua | 13 ++++++++-----
+ 1 file changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/lua-resty-core-0.1.22/lib/resty/core/socket.lua b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+index 15e3065..879d678 100644
+--- a/lua-resty-core-0.1.22/lib/resty/core/socket.lua
++++ b/lua-resty-core-0.1.22/lib/resty/core/socket.lua
+@@ -150,24 +150,27 @@ local function setclientcert(cosocket, cert, pkey)
+     if not cert and not pkey then
+         cosocket.client_cert = nil
+         cosocket.client_pkey = nil
+-        return
++        return true
+     end
+ 
+     if not cert or not pkey then
+-        error("client certificate must be supplied with corresponding " ..
+-              "private key", 2)
++        return nil,
++               "client certificate must be supplied with corresponding " ..
++               "private key"
+     end
+ 
+     if type(cert) ~= "cdata" then
+-        error("bad client cert type", 2)
++        return nil, "bad client cert type"
+     end
+ 
+     if type(pkey) ~= "cdata" then
+-        error("bad client pkey type", 2)
++        return nil, "bad client pkey type"
+     end
+ 
+     cosocket.client_cert = cert
+     cosocket.client_pkey = pkey
++
++    return true
+ end
+ 
+ 
 -- 
 2.32.0 (Apple Git-132)
 

--- a/openresty-patches/patches/1.19.9.1/lua-resty-websocket-0.08_01-client-mtls.patch
+++ b/openresty-patches/patches/1.19.9.1/lua-resty-websocket-0.08_01-client-mtls.patch
@@ -1,7 +1,7 @@
 From 05d0832cf96c216297810cb495706c50309b8c5a Mon Sep 17 00:00:00 2001
 From: James Hurst <james@reel.audio>
 Date: Mon, 7 Feb 2022 11:36:25 +0000
-Subject: [PATCH] feat: add mtls client cert support
+Subject: [PATCH 1/2] feat: add mtls client cert support
 
 ---
  lib/resty/websocket/client.lua | 26 ++++++++++++++++++++++----
@@ -61,6 +61,32 @@ index 067b2a5..2ec96dd 100644
          if not ok then
              return nil, "ssl handshake failed: " .. err
          end
+-- 
+2.32.0 (Apple Git-132)
+
+
+From fcf3370eef554cd4e1791ac92c43b420d25d66a1 Mon Sep 17 00:00:00 2001
+From: James Hurst <james@reel.audio>
+Date: Mon, 7 Feb 2022 15:20:48 +0000
+Subject: [PATCH 2/2] fix(client) fix typo in error message
+
+---
+ lib/resty/websocket/client.lua | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lua-resty-websocket-0.08/lib/resty/websocket/client.lua b/lua-resty-websocket-0.08/lib/resty/websocket/client.lua
+index 2ec96dd..598543f 100644
+--- a/lua-resty-websocket-0.08/lib/resty/websocket/client.lua
++++ b/lua-resty-websocket-0.08/lib/resty/websocket/client.lua
+@@ -165,7 +165,7 @@ function _M.connect(self, uri, opts)
+         if client_cert then
+             ok, err = sock:setclientcert(client_cert, client_priv_key)
+             if not ok then
+-                return nil, "ssl client cert failued: " .. err
++                return nil, "ssl client cert failed: " .. err
+             end
+         end
+ 
 -- 
 2.32.0 (Apple Git-132)
 

--- a/openresty-patches/patches/1.19.9.1/lua-resty-websocket-0.08_01-client-mtls.patch
+++ b/openresty-patches/patches/1.19.9.1/lua-resty-websocket-0.08_01-client-mtls.patch
@@ -1,64 +1,66 @@
+From 05d0832cf96c216297810cb495706c50309b8c5a Mon Sep 17 00:00:00 2001
+From: James Hurst <james@reel.audio>
+Date: Mon, 7 Feb 2022 11:36:25 +0000
+Subject: [PATCH] feat: add mtls client cert support
+
+---
+ lib/resty/websocket/client.lua | 26 ++++++++++++++++++++++----
+ 1 file changed, 22 insertions(+), 4 deletions(-)
+
 diff --git a/lua-resty-websocket-0.08/lib/resty/websocket/client.lua b/lua-resty-websocket-0.08/lib/resty/websocket/client.lua
-index 13d4b99..47dc4c2 100644
+index 067b2a5..2ec96dd 100644
 --- a/lua-resty-websocket-0.08/lib/resty/websocket/client.lua
 +++ b/lua-resty-websocket-0.08/lib/resty/websocket/client.lua
-@@ -98,7 +98,7 @@ function _M.connect(self, uri, opts)
+@@ -98,7 +98,8 @@ function _M.connect(self, uri, opts)
          path = "/"
      end
-
+ 
 -    local ssl_verify, headers, proto_header, origin_header, sock_opts = false
-+    local ssl_verify, headers, proto_header, origin_header, sock_opts, tls_opts = false
-
++    local ssl_verify, server_name, headers, proto_header, origin_header, sock_opts = false
++    local client_cert, client_priv_key
+ 
      if opts then
          local protos = opts.protocols
-@@ -122,11 +122,37 @@ function _M.connect(self, uri, opts)
+@@ -122,11 +123,20 @@ function _M.connect(self, uri, opts)
              sock_opts = { pool = pool }
          end
  
-+        local client_cert = opts.client_cert
-+        local client_priv_key = opts.client_priv_key
+-        if opts.ssl_verify then
++        client_cert = opts.client_cert
++        client_priv_key = opts.client_priv_key
 +
 +        if client_cert then
 +            assert(client_priv_key,
 +                   "client_priv_key must be provided with client_cert")
-+
-+            tls_opts = { client_cert = client_cert,
-+                         client_priv_key = client_priv_key, }
 +        end
 +
-         if opts.ssl_verify then
++        if opts.ssl_verify or opts.server_name then
              if not ssl_support then
                  return nil, "ngx_lua 0.9.11+ required for SSL sockets"
              end
 -            ssl_verify = true
-+
-+            tls_opts = tls_opts or {}
-+            tls_opts.verify = true
-+        end
-+
-+        if opts.server_name then
-+            if not ssl_support then
-+                return nil, "ngx_lua 0.9.11+ required for SSL sockets"
-+            end
-+
-+            tls_opts = tls_opts or {}
-+            tls_opts.server_name = opts.server_name
-+
-+        elseif host then
-+            tls_opts = tls_opts or {}
-+            tls_opts.server_name = host
++            ssl_verify = opts.ssl_verify
++            server_name = opts.server_name or host
          end
  
          if opts.headers then
-@@ -151,9 +177,9 @@ function _M.connect(self, uri, opts)
+@@ -151,7 +161,15 @@ function _M.connect(self, uri, opts)
          if not ssl_support then
              return nil, "ngx_lua 0.9.11+ required for SSL sockets"
          end
 -        ok, err = sock:sslhandshake(false, host, ssl_verify)
-+        ok, err = sock:tlshandshake(tls_opts)
++
++        if client_cert then
++            ok, err = sock:setclientcert(client_cert, client_priv_key)
++            if not ok then
++                return nil, "ssl client cert failued: " .. err
++            end
++        end
++
++        ok, err = sock:sslhandshake(false, server_name, ssl_verify)
          if not ok then
--            return nil, "ssl handshake failed: " .. err
-+            return nil, "tls handshake failed: " .. err
+             return nil, "ssl handshake failed: " .. err
          end
-     end
+-- 
+2.32.0 (Apple Git-132)
 

--- a/openresty-patches/patches/1.19.9.1/ngx_lua-0.10.20_01-cosocket-mtls.patch
+++ b/openresty-patches/patches/1.19.9.1/ngx_lua-0.10.20_01-cosocket-mtls.patch
@@ -1,7 +1,128 @@
-From 9bec4f8703054c91534570d6985e3a83843c8ac5 Mon Sep 17 00:00:00 2001
+From acd53645754ce42b436cecb0d7a10b547d41fef6 Mon Sep 17 00:00:00 2001
+From: lijunlong <lijunlong@openresty.com>
+Date: Wed, 13 Oct 2021 23:42:17 +0800
+Subject: [PATCH 01/17] bugfix: nginx crash when resolve an not exist domain in
+ thread create by ngx.thread.spawn.(#1931)
+
+FIX #1915
+The resolve ctxes were dded to a link list.  function ngx_resolver_process_a iterate through the link list when got the DNS reply.
+When processing the first resolve ctx, all the three ctxes were freed. So when ngx_resolver_process_a continues to process the second ctx, it will free the ctx again.
+
+Co-authored-by: doujiang24 <doujiang24@gmail.com>
+---
+ src/ngx_http_lua_socket_tcp.c | 15 ++-------------
+ 1 file changed, 2 insertions(+), 13 deletions(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index 55bd203d..b7c3bdd4 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -147,8 +147,6 @@ static void ngx_http_lua_socket_free_pool(ngx_log_t *log,
+ static int ngx_http_lua_socket_shutdown_pool(lua_State *L);
+ static void ngx_http_lua_socket_shutdown_pool_helper(
+     ngx_http_lua_socket_pool_t *spool);
+-static void
+-    ngx_http_lua_socket_empty_resolve_handler(ngx_resolver_ctx_t *ctx);
+ static int ngx_http_lua_socket_prepare_error_retvals(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L, ngx_uint_t ft_type);
+ #if (NGX_HTTP_SSL)
+@@ -1151,13 +1149,6 @@ ngx_http_lua_socket_tcp_connect(lua_State *L)
+ }
+ 
+ 
+-static void
+-ngx_http_lua_socket_empty_resolve_handler(ngx_resolver_ctx_t *ctx)
+-{
+-    /* do nothing */
+-}
+-
+-
+ static void
+ ngx_http_lua_socket_resolve_handler(ngx_resolver_ctx_t *ctx)
+ {
+@@ -6084,10 +6075,8 @@ ngx_http_lua_tcp_resolve_cleanup(void *data)
+         return;
+     }
+ 
+-    /* just to be safer */
+-    rctx->handler = ngx_http_lua_socket_empty_resolve_handler;
+-
+-    ngx_resolve_name_done(rctx);
++    /* postpone free the rctx in the handler */
++    rctx->handler = ngx_resolve_name_done;
+ }
+ 
+ 
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 59d39ca2f0963695052c2593f957053f1a1779a2 Mon Sep 17 00:00:00 2001
+From: Josh Soref <2119212+jsoref@users.noreply.github.com>
+Date: Mon, 25 Oct 2021 03:07:01 -0400
+Subject: [PATCH 02/17] doc: fixed spelling errors in the docs and code.
+ (#1947)
+
+---
+ src/ngx_http_lua_socket_tcp.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index b7c3bdd4..ace18a0f 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -3112,7 +3112,7 @@ ngx_http_lua_socket_tcp_settimeout(lua_State *L)
+     n = lua_gettop(L);
+ 
+     if (n != 2) {
+-        return luaL_error(L, "ngx.socket settimout: expecting 2 arguments "
++        return luaL_error(L, "ngx.socket settimeout: expecting 2 arguments "
+                           "(including the object) but seen %d", lua_gettop(L));
+     }
+ 
+@@ -3159,7 +3159,7 @@ ngx_http_lua_socket_tcp_settimeouts(lua_State *L)
+     n = lua_gettop(L);
+ 
+     if (n != 4) {
+-        return luaL_error(L, "ngx.socket settimout: expecting 4 arguments "
++        return luaL_error(L, "ngx.socket settimeout: expecting 4 arguments "
+                           "(including the object) but seen %d", lua_gettop(L));
+     }
+ 
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 617cb5dadc14dddb4796d4fff8821dae325f4229 Mon Sep 17 00:00:00 2001
+From: Sharp Liu <cppcoffee@gmail.com>
+Date: Tue, 26 Oct 2021 17:53:54 +0800
+Subject: [PATCH 03/17] style: removed extra space. (#1952)
+
+---
+ src/ngx_http_lua_socket_tcp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index ace18a0f..26467fdd 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -2825,7 +2825,7 @@ ngx_http_lua_socket_tcp_send(lua_State *L)
+ 
+     switch (type) {
+         case LUA_TNUMBER:
+-            b->last  = ngx_http_lua_write_num(L, 2, b->last);
++            b->last = ngx_http_lua_write_num(L, 2, b->last);
+             break;
+ 
+         case LUA_TSTRING:
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 287d58810c450f912a8d31a94a1c86ccc039c0e1 Mon Sep 17 00:00:00 2001
 From: Datong Sun <datong.sun@konghq.com>
 Date: Wed, 18 Sep 2019 16:39:05 -0700
-Subject: [PATCH 1/5] cosocket: add function `tcpsock:tlshandshake`, retired
+Subject: [PATCH 04/17] cosocket: add function `tcpsock:tlshandshake`, retired
  the Lua C API based `tcpsock:sslhandshake` implementation.
 
 ---
@@ -10,7 +131,7 @@ Subject: [PATCH 1/5] cosocket: add function `tcpsock:tlshandshake`, retired
  2 files changed, 177 insertions(+), 213 deletions(-)
 
 diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
-index 30a4e7b2..2551b5a7 100644
+index 26467fdd..4ef22c11 100644
 --- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
 +++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
 @@ -23,6 +23,9 @@ static int ngx_http_lua_socket_tcp(lua_State *L);
@@ -23,8 +144,8 @@ index 30a4e7b2..2551b5a7 100644
  #endif
  static int ngx_http_lua_socket_tcp_receive(lua_State *L);
  static int ngx_http_lua_socket_tcp_receiveany(lua_State *L);
-@@ -151,12 +154,6 @@ static void
-     ngx_http_lua_socket_empty_resolve_handler(ngx_resolver_ctx_t *ctx);
+@@ -149,12 +152,6 @@ static void ngx_http_lua_socket_shutdown_pool_helper(
+     ngx_http_lua_socket_pool_t *spool);
  static int ngx_http_lua_socket_prepare_error_retvals(ngx_http_request_t *r,
      ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L, ngx_uint_t ft_type);
 -#if (NGX_HTTP_SSL)
@@ -34,12 +155,12 @@ index 30a4e7b2..2551b5a7 100644
 -static int ngx_http_lua_ssl_free_session(lua_State *L);
 -#endif
  static void ngx_http_lua_socket_tcp_close_connection(ngx_connection_t *c);
-
-
-@@ -326,13 +323,6 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
+ 
+ 
+@@ -324,13 +321,6 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
      lua_pushcfunction(L, ngx_http_lua_socket_tcp_connect);
      lua_setfield(L, -2, "connect");
-
+ 
 -#if (NGX_HTTP_SSL)
 -
 -    lua_pushcfunction(L, ngx_http_lua_socket_tcp_sslhandshake);
@@ -49,8 +170,8 @@ index 30a4e7b2..2551b5a7 100644
 -
      lua_pushcfunction(L, ngx_http_lua_socket_tcp_receive);
      lua_setfield(L, -2, "receive");
-
-@@ -406,19 +396,6 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
+ 
+@@ -404,19 +394,6 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
      lua_setfield(L, -2, "__gc");
      lua_rawset(L, LUA_REGISTRYINDEX);
      /* }}} */
@@ -68,12 +189,12 @@ index 30a4e7b2..2551b5a7 100644
 -
 -#endif
  }
-
-
-@@ -1568,64 +1545,69 @@ ngx_http_lua_socket_conn_error_retval_handler(ngx_http_request_t *r,
-
+ 
+ 
+@@ -1559,64 +1536,69 @@ ngx_http_lua_socket_conn_error_retval_handler(ngx_http_request_t *r,
+ 
  #if (NGX_HTTP_SSL)
-
+ 
 -static int
 -ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
 +static const char *
@@ -96,7 +217,7 @@ index 30a4e7b2..2551b5a7 100644
 +    if (ops & SOCKET_OP_CONNECT && u->conn_waiting) {
 +        return "socket busy connecting";
 +    }
-
+ 
 -    n = lua_gettop(L);
 -    if (n < 1 || n > 5) {
 -        return luaL_error(L, "ngx.socket sslhandshake: expecting 1 ~ 5 "
@@ -104,7 +225,7 @@ index 30a4e7b2..2551b5a7 100644
 +    if (ops & SOCKET_OP_READ && u->read_waiting) {
 +        return "socket busy reading";
      }
-
+ 
 -    r = ngx_http_lua_get_req(L);
 -    if (r == NULL) {
 -        return luaL_error(L, "no request found");
@@ -115,12 +236,12 @@ index 30a4e7b2..2551b5a7 100644
 +    {
 +        return "socket busy writing";
      }
-
+ 
 -    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
 -                   "lua tcp socket ssl handshake");
 +    return NULL;
 +}
-
+ 
 -    luaL_checktype(L, 1, LUA_TTABLE);
 +int
 +ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
@@ -133,12 +254,12 @@ index 30a4e7b2..2551b5a7 100644
 +    ngx_http_lua_ctx_t      *ctx;
 +    ngx_http_lua_co_ctx_t   *coctx;
 +    const char              *busy_rc;
-
+ 
 -    lua_rawgeti(L, 1, SOCKET_CTX_INDEX);
 -    u = lua_touserdata(L, -1);
 +    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
 +                   "lua tcp socket tls handshake");
-
+ 
      if (u == NULL
          || u->peer.connection == NULL
          || u->read_closed
@@ -150,13 +271,13 @@ index 30a4e7b2..2551b5a7 100644
 +        *errmsg = "closed";
 +        return NGX_ERROR;
      }
-
+ 
      if (u->request != r) {
 -        return luaL_error(L, "bad request");
 +        *errmsg = "bad request";
 +        return NGX_ERROR;
      }
-
+ 
 -    ngx_http_lua_socket_check_busy_connecting(r, u, L);
 -    ngx_http_lua_socket_check_busy_reading(r, u, L);
 -    ngx_http_lua_socket_check_busy_writing(r, u, L);
@@ -167,7 +288,7 @@ index 30a4e7b2..2551b5a7 100644
 +        *errmsg = busy_rc;
 +        return NGX_ERROR;
 +    }
-
+ 
      if (u->raw_downstream || u->body_downstream) {
 -        lua_pushnil(L);
 -        lua_pushliteral(L, "not supported for downstream");
@@ -175,11 +296,11 @@ index 30a4e7b2..2551b5a7 100644
 +        *errmsg = "not supported for downstream";
 +        return NGX_ERROR;
      }
-
+ 
      c = u->peer.connection;
-@@ -1633,122 +1615,96 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
+@@ -1624,122 +1606,96 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
      u->ssl_session_reuse = 1;
-
+ 
      if (c->ssl && c->ssl->handshaked) {
 -        switch (lua_type(L, 2)) {
 -        case LUA_TUSERDATA:
@@ -188,7 +309,7 @@ index 30a4e7b2..2551b5a7 100644
 +        if (sess != NULL) {
 +            return NGX_DONE;
 +        }
-
+ 
 -        case LUA_TBOOLEAN:
 -            if (!lua_toboolean(L, 2)) {
 -                /* avoid generating the ssl session */
@@ -197,17 +318,17 @@ index 30a4e7b2..2551b5a7 100644
 -            }
 -            /* fall through */
 +        u->ssl_session_reuse = enable_session_reuse;
-
+ 
 -        default:
 -            ngx_http_lua_ssl_handshake_retval_handler(r, u, L);
 -            break;
 -        }
 +        (void) ngx_http_lua_tls_handshake_retval_handler(r, u, NULL);
-
+ 
 -        return 1;
 +        return NGX_OK;
      }
-
+ 
      if (ngx_ssl_create_connection(u->conf->ssl, c,
                                    NGX_SSL_BUFFER|NGX_SSL_CLIENT)
          != NGX_OK)
@@ -218,7 +339,7 @@ index 30a4e7b2..2551b5a7 100644
 +        *errmsg = "failed to create ssl connection";
 +        return NGX_ERROR;
      }
-
+ 
      ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
      if (ctx == NULL) {
 -        return luaL_error(L, "no ctx found");
@@ -230,11 +351,11 @@ index 30a4e7b2..2551b5a7 100644
 +        *errmsg = "no ctx found";
 +        return NGX_ERROR;
      }
-
+ 
      coctx = ctx->cur_co_ctx;
-
+ 
      c->sendfile = 0;
-
+ 
 -    if (n >= 2) {
 -        if (lua_type(L, 2) == LUA_TBOOLEAN) {
 -            u->ssl_session_reuse = lua_toboolean(L, 2);
@@ -257,12 +378,12 @@ index 30a4e7b2..2551b5a7 100644
 +            *errmsg = "lua tls set session failed";
 +            return NGX_ERROR;
          }
-
+ 
 -        if (n >= 3) {
 -            name.data = (u_char *) lua_tolstring(L, 3, &name.len);
 +        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
 +                       "lua tls set session: %p", sess);
-
+ 
 -            if (name.data) {
 -                ngx_log_debug2(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
 -                               "lua ssl server name: \"%*s\"", name.len,
@@ -270,12 +391,12 @@ index 30a4e7b2..2551b5a7 100644
 +    } else {
 +        u->ssl_session_reuse = enable_session_reuse;
 +    }
-
+ 
 -#ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
 +    if (server_name != NULL && server_name->data != NULL) {
 +        ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
 +                       "lua tls server name: \"%V\"", server_name);
-
+ 
 -                if (SSL_set_tlsext_host_name(c->ssl->connection,
 -                                             (char *) name.data)
 -                    == 0)
@@ -292,7 +413,7 @@ index 30a4e7b2..2551b5a7 100644
 +            *errmsg = "SSL_set_tlsext_host_name failed";
 +            return NGX_ERROR;
 +        }
-
+ 
  #else
 -
 -               ngx_log_debug0(NGX_LOG_DEBUG_HTTP, c->log, 0,
@@ -304,11 +425,11 @@ index 30a4e7b2..2551b5a7 100644
  #endif
 -            }
 +    }
-
+ 
 -            if (n >= 4) {
 -                u->ssl_verify = lua_toboolean(L, 4);
 +    u->ssl_verify = verify;
-
+ 
 -                if (n >= 5) {
 -                    if (lua_toboolean(L, 5)) {
 +    if (ocsp_status_req) {
@@ -328,17 +449,17 @@ index 30a4e7b2..2551b5a7 100644
 -            }
 -        }
      }
-
+ 
 -    dd("found sni name: %.*s %p", (int) name.len, name.data, name.data);
 -
 -    if (name.len == 0) {
 +    if (server_name->len == 0) {
          u->ssl_name.len = 0;
-
+ 
      } else {
          if (u->ssl_name.data) {
              /* buffer already allocated */
-
+ 
 -            if (u->ssl_name.len >= name.len) {
 +            if (u->ssl_name.len >= server_name->len) {
                  /* reuse it */
@@ -346,62 +467,62 @@ index 30a4e7b2..2551b5a7 100644
 -                u->ssl_name.len = name.len;
 +                ngx_memcpy(u->ssl_name.data, server_name->data, server_name->len);
 +                u->ssl_name.len = server_name->len;
-
+ 
              } else {
                  ngx_free(u->ssl_name.data);
-@@ -1759,17 +1715,16 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
-
+@@ -1750,17 +1706,16 @@ ngx_http_lua_socket_tcp_sslhandshake(lua_State *L)
+ 
  new_ssl_name:
-
+ 
 -            u->ssl_name.data = ngx_alloc(name.len, ngx_cycle->log);
 +            u->ssl_name.data = ngx_alloc(server_name->len, ngx_cycle->log);
              if (u->ssl_name.data == NULL) {
                  u->ssl_name.len = 0;
-
+ 
 -                lua_pushnil(L);
 -                lua_pushliteral(L, "no memory");
 -                return 2;
 +                *errmsg = "no memory";
 +                return NGX_ERROR;
              }
-
+ 
 -            ngx_memcpy(u->ssl_name.data, name.data, name.len);
 -            u->ssl_name.len = name.len;
 +            ngx_memcpy(u->ssl_name.data, server_name->data, server_name->len);
 +            u->ssl_name.len = server_name->len;
          }
      }
-
-@@ -1783,7 +1738,8 @@ new_ssl_name:
-
+ 
+@@ -1774,7 +1729,8 @@ new_ssl_name:
+ 
      rc = ngx_ssl_handshake(c);
-
+ 
 -    dd("ngx_ssl_handshake returned %d", (int) rc);
 +    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
 +                   "ngx_ssl_handshake returned %d", rc);
-
+ 
      if (rc == NGX_AGAIN) {
          if (c->write->timer_set) {
-@@ -1793,13 +1749,13 @@ new_ssl_name:
+@@ -1784,13 +1740,13 @@ new_ssl_name:
          ngx_add_timer(c->read, u->connect_timeout);
-
+ 
          u->conn_waiting = 1;
 -        u->write_prepare_retvals = ngx_http_lua_ssl_handshake_retval_handler;
 +        u->write_prepare_retvals = ngx_http_lua_tls_handshake_retval_handler;
-
+ 
          ngx_http_lua_cleanup_pending_operation(coctx);
          coctx->cleanup = ngx_http_lua_coctx_cleanup;
          coctx->data = u;
-
+ 
 -        c->ssl->handler = ngx_http_lua_ssl_handshake_handler;
 +        c->ssl->handler = ngx_http_lua_tls_handshake_handler;
-
+ 
          if (ctx->entered_content_phase) {
              r->write_event_handler = ngx_http_lua_content_wev_handler;
-@@ -1808,21 +1764,25 @@ new_ssl_name:
+@@ -1799,21 +1755,25 @@ new_ssl_name:
              r->write_event_handler = ngx_http_core_run_phases;
          }
-
+ 
 -        return lua_yield(L, 0);
 +        return NGX_AGAIN;
 +    }
@@ -413,14 +534,14 @@ index 30a4e7b2..2551b5a7 100644
 +
 +        return NGX_ERROR;
      }
-
+ 
 -    top = lua_gettop(L);
 -    ngx_http_lua_ssl_handshake_handler(c);
 -    return lua_gettop(L) - top;
 +    return NGX_OK;
  }
-
-
+ 
+ 
  static void
 -ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
 +ngx_http_lua_tls_handshake_handler(ngx_connection_t *c)
@@ -431,34 +552,34 @@ index 30a4e7b2..2551b5a7 100644
      ngx_int_t                    rc;
      ngx_connection_t            *dc;  /* downstream connection */
      ngx_http_request_t          *r;
-@@ -1845,11 +1805,9 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
+@@ -1836,11 +1796,9 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
      waiting = u->conn_waiting;
-
+ 
      dc = r->connection;
 -    L = u->write_co_ctx->co;
-
+ 
      if (c->read->timedout) {
 -        lua_pushnil(L);
 -        lua_pushliteral(L, "timeout");
 +        u->error_ret = "timeout";
          goto failed;
      }
-
-@@ -1858,19 +1805,18 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
+ 
+@@ -1849,19 +1807,18 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
      }
-
+ 
      if (c->ssl->handshaked) {
 -
          if (u->ssl_verify) {
              rc = SSL_get_verify_result(c->ssl->connection);
-
+ 
              if (rc != X509_V_OK) {
 -                lua_pushnil(L);
 -                err = lua_pushfstring(L, "%d: %s", (int) rc,
 -                                      X509_verify_cert_error_string(rc));
 +                u->error_ret = X509_verify_cert_error_string(rc);
 +                u->openssl_error_code_ret = rc;
-
+ 
                  llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
                  if (llcf->log_socket_errors) {
 -                    ngx_log_error(NGX_LOG_ERR, dc->log, 0, "lua ssl "
@@ -467,16 +588,16 @@ index 30a4e7b2..2551b5a7 100644
 +                                  "certificate verify error: (%d: %s)",
 +                                  rc, u->error_ret);
                  }
-
+ 
                  goto failed;
-@@ -1881,12 +1838,11 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
+@@ -1872,12 +1829,11 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
              if (u->ssl_name.len
                  && ngx_ssl_check_host(c, &u->ssl_name) != NGX_OK)
              {
 -                lua_pushnil(L);
 -                lua_pushliteral(L, "certificate host mismatch");
 +                u->error_ret = "certificate host mismatch";
-
+ 
                  llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
                  if (llcf->log_socket_errors) {
 -                    ngx_log_error(NGX_LOG_ERR, dc->log, 0, "lua ssl "
@@ -484,25 +605,25 @@ index 30a4e7b2..2551b5a7 100644
                                    "certificate does not match host \"%V\"",
                                    &u->ssl_name);
                  }
-@@ -1901,7 +1857,7 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
+@@ -1892,7 +1848,7 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
              ngx_http_lua_socket_handle_conn_success(r, u);
-
+ 
          } else {
 -            (void) ngx_http_lua_ssl_handshake_retval_handler(r, u, L);
 +            (void) ngx_http_lua_tls_handshake_retval_handler(r, u, NULL);
          }
-
+ 
          if (waiting) {
-@@ -1911,60 +1867,84 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
+@@ -1902,60 +1858,84 @@ ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
          return;
      }
-
+ 
 -    lua_pushnil(L);
 -    lua_pushliteral(L, "handshake failed");
 +    u->error_ret = "handshake failed";
-
+ 
  failed:
-
+ 
      if (waiting) {
          u->write_prepare_retvals =
 -                                ngx_http_lua_socket_conn_error_retval_handler;
@@ -511,16 +632,16 @@ index 30a4e7b2..2551b5a7 100644
 +            ngx_http_lua_socket_conn_error_retval_handler;
 +        ngx_http_lua_socket_handle_conn_error(r, u, NGX_HTTP_LUA_SOCKET_FT_SSL);
          ngx_http_run_posted_requests(dc);
-
+ 
      } else {
 -        (void) ngx_http_lua_socket_conn_error_retval_handler(r, u, L);
 +        u->ft_type |= NGX_HTTP_LUA_SOCKET_FT_SSL;
 +
 +        (void) ngx_http_lua_socket_conn_error_retval_handler(r, u, NULL);
-     }
- }
-
-
++    }
++}
++
++
 +
 +int
 +ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(ngx_http_request_t *r,
@@ -535,14 +656,14 @@ index 30a4e7b2..2551b5a7 100644
 +        *openssl_error_code = u->openssl_error_code_ret;
 +
 +        return NGX_ERROR;
-+    }
+     }
 +
 +    *sess = u->ssl_session_ret;
 +
 +    return NGX_OK;
-+}
-+
-+
+ }
+ 
+ 
  static int
 -ngx_http_lua_ssl_handshake_retval_handler(ngx_http_request_t *r,
 +ngx_http_lua_tls_handshake_retval_handler(ngx_http_request_t *r,
@@ -551,26 +672,26 @@ index 30a4e7b2..2551b5a7 100644
      ngx_connection_t            *c;
 -    ngx_ssl_session_t           *ssl_session, **ud;
 +    ngx_ssl_session_t           *ssl_session;
-
+ 
      if (!u->ssl_session_reuse) {
 -        lua_pushboolean(L, 1);
 -        return 1;
 +        return 0;
      }
-
+ 
 -    ud = lua_newuserdata(L, sizeof(ngx_ssl_session_t *));
 -
      c = u->peer.connection;
-
+ 
      ssl_session = ngx_ssl_get_session(c);
      if (ssl_session == NULL) {
 -        *ud = NULL;
 +        u->ssl_session_ret = NULL;
-
+ 
      } else {
 -        *ud = ssl_session;
 +        u->ssl_session_ret = ssl_session;
-
+ 
          ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
 -                       "lua ssl save session: %p", ssl_session);
 -
@@ -581,11 +702,11 @@ index 30a4e7b2..2551b5a7 100644
 -        lua_setmetatable(L, -2);
 +                       "lua tls save session: %p", ssl_session);
      }
-
+ 
 -    return 1;
 +    return 0;
- }
-
++}
++
 +
 +void
 +ngx_http_lua_ffi_tls_free_session(ngx_ssl_session_t *sess)
@@ -594,34 +715,34 @@ index 30a4e7b2..2551b5a7 100644
 +                   "lua tls free session: %p", sess);
 +
 +    ngx_ssl_free_session(sess);
-+}
-+
+ }
+ 
 +
  #endif  /* NGX_HTTP_SSL */
-
-
-@@ -2017,12 +1997,14 @@ ngx_http_lua_socket_prepare_error_retvals(ngx_http_request_t *r,
+ 
+ 
+@@ -2008,12 +1988,14 @@ ngx_http_lua_socket_prepare_error_retvals(ngx_http_request_t *r,
      u_char           errstr[NGX_MAX_ERROR_STR];
      u_char          *p;
-
+ 
 -    if (ft_type & (NGX_HTTP_LUA_SOCKET_FT_RESOLVER
 -                   | NGX_HTTP_LUA_SOCKET_FT_SSL))
 -    {
 +    if (ft_type & NGX_HTTP_LUA_SOCKET_FT_RESOLVER) {
          return 2;
      }
-
+ 
 +    if (ft_type & NGX_HTTP_LUA_SOCKET_FT_SSL) {
 +        return 0;
 +    }
 +
      lua_pushnil(L);
-
+ 
      if (ft_type & NGX_HTTP_LUA_SOCKET_FT_TIMEOUT) {
-@@ -6112,27 +6094,6 @@ ngx_http_lua_coctx_cleanup(void *data)
+@@ -6101,27 +6083,6 @@ ngx_http_lua_coctx_cleanup(void *data)
  }
-
-
+ 
+ 
 -#if (NGX_HTTP_SSL)
 -
 -static int
@@ -647,27 +768,27 @@ index 30a4e7b2..2551b5a7 100644
  ngx_http_lua_cleanup_conn_pools(lua_State *L)
  {
 diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.h b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.h
-index 091e4378..bb618702 100644
+index a0a5a518..ee9411bc 100644
 --- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.h
 +++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.h
 @@ -120,6 +120,9 @@ struct ngx_http_lua_socket_tcp_upstream_s {
-
+ 
  #if (NGX_HTTP_SSL)
      ngx_str_t                        ssl_name;
 +    ngx_ssl_session_t               *ssl_session_ret;
 +    const char                      *error_ret;
 +    int                              openssl_error_code_ret;
  #endif
-
+ 
      unsigned                         ft_type:16;
---
-2.26.2
+-- 
+2.32.0 (Apple Git-132)
 
 
-From 958140f6113bc4ac33f0880682097f52682d0b81 Mon Sep 17 00:00:00 2001
+From f5ba21d6f742e6b169d972a81b6124b27c076016 Mon Sep 17 00:00:00 2001
 From: Datong Sun <datong.sun@konghq.com>
 Date: Wed, 18 Sep 2019 16:54:32 -0700
-Subject: [PATCH 2/5] change: better error when request context couldn't be
+Subject: [PATCH 05/17] change: better error when request context couldn't be
  found.
 
 ---
@@ -675,11 +796,11 @@ Subject: [PATCH 2/5] change: better error when request context couldn't be
  1 file changed, 1 insertion(+), 7 deletions(-)
 
 diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
-index 2551b5a7..8ae931bd 100644
+index 4ef22c11..abd487fa 100644
 --- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
 +++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
-@@ -1636,13 +1636,7 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
-
+@@ -1627,13 +1627,7 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+ 
      ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
      if (ctx == NULL) {
 -        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
@@ -691,24 +812,24 @@ index 2551b5a7..8ae931bd 100644
 -        return NGX_ERROR;
 +        return NGX_HTTP_LUA_FFI_NO_REQ_CTX;
      }
-
+ 
      coctx = ctx->cur_co_ctx;
---
-2.26.2
+-- 
+2.32.0 (Apple Git-132)
 
 
-From 10bfa00f44a474d0c7667517d98243732c447612 Mon Sep 17 00:00:00 2001
+From 78a450d571febf7ba918ecc13369144925d02bcb Mon Sep 17 00:00:00 2001
 From: Datong Sun <datong.sun@konghq.com>
 Date: Wed, 18 Sep 2019 17:24:07 -0700
-Subject: [PATCH 3/5] feature: TCP cosocket client certificate support. closes
- #534
+Subject: [PATCH 06/17] feature: TCP cosocket client certificate support.
+ closes #534
 
 ---
  src/ngx_http_lua_socket_tcp.c | 60 +++++++++++++++++++++++++++++++----
  1 file changed, 54 insertions(+), 6 deletions(-)
 
 diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
-index 8ae931bd..f49e609c 100644
+index abd487fa..61671b70 100644
 --- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
 +++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
 @@ -22,7 +22,6 @@
@@ -719,17 +840,17 @@ index 8ae931bd..f49e609c 100644
  static void ngx_http_lua_tls_handshake_handler(ngx_connection_t *c);
  static int ngx_http_lua_tls_handshake_retval_handler(ngx_http_request_t *r,
      ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L);
-@@ -221,9 +220,6 @@ static char ngx_http_lua_upstream_udata_metatable_key;
+@@ -219,9 +218,6 @@ static char ngx_http_lua_upstream_udata_metatable_key;
  static char ngx_http_lua_downstream_udata_metatable_key;
  static char ngx_http_lua_pool_udata_metatable_key;
  static char ngx_http_lua_pattern_udata_metatable_key;
 -#if (NGX_HTTP_SSL)
 -static char ngx_http_lua_ssl_session_metatable_key;
 -#endif
-
-
+ 
+ 
  #define ngx_http_lua_tcp_socket_metatable_literal_key  "__tcp_cosocket_mt"
-@@ -1572,13 +1568,16 @@ int
+@@ -1563,13 +1559,16 @@ int
  ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
      ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t *sess,
      int enable_session_reuse, ngx_str_t *server_name, int verify,
@@ -745,22 +866,22 @@ index 8ae931bd..f49e609c 100644
      const char              *busy_rc;
 +    ngx_ssl_conn_t          *ssl_conn;
 +    X509                    *x509;
-
+ 
      ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                     "lua tcp socket tls handshake");
-@@ -1634,6 +1633,8 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+@@ -1625,6 +1624,8 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
          return NGX_ERROR;
      }
-
+ 
 +    ssl_conn = c->ssl->connection;
 +
      ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
      if (ctx == NULL) {
          return NGX_HTTP_LUA_FFI_NO_REQ_CTX;
-@@ -1656,6 +1657,53 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+@@ -1647,6 +1648,53 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
          u->ssl_session_reuse = enable_session_reuse;
      }
-
+ 
 +    if (chain != NULL) {
 +        ngx_http_lua_assert(pkey != NULL); /* ensured by resty.core */
 +
@@ -811,77 +932,77 @@ index 8ae931bd..f49e609c 100644
      if (server_name != NULL && server_name->data != NULL) {
          ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
                         "lua tls server name: \"%V\"", server_name);
---
-2.26.2
+-- 
+2.32.0 (Apple Git-132)
 
 
-From 87e157b594987a63d797fd74907c00c3ed69dc19 Mon Sep 17 00:00:00 2001
+From 6cc0c89e946ef42adfbc55e8a461ccc2f367254a Mon Sep 17 00:00:00 2001
 From: Datong Sun <datong.sun@konghq.com>
 Date: Wed, 18 Sep 2019 17:25:20 -0700
-Subject: [PATCH 4/5] style: style fixes.
+Subject: [PATCH 07/17] style: style fixes.
 
 ---
  src/ngx_http_lua_socket_tcp.c | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
-index f49e609c..ce8132d3 100644
+index 61671b70..a7d410c9 100644
 --- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
 +++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
-@@ -1745,7 +1745,8 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
-
+@@ -1736,7 +1736,8 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+ 
              if (u->ssl_name.len >= server_name->len) {
                  /* reuse it */
 -                ngx_memcpy(u->ssl_name.data, server_name->data, server_name->len);
 +                ngx_memcpy(u->ssl_name.data, server_name->data,
 +                           server_name->len);
                  u->ssl_name.len = server_name->len;
-
+ 
              } else {
---
-2.26.2
+-- 
+2.32.0 (Apple Git-132)
 
 
-From f1d1b6352eb6d386593263e80ba3eab0ba710f59 Mon Sep 17 00:00:00 2001
+From 21cd7779252732a02fa0e596b66a1d4663d2fd64 Mon Sep 17 00:00:00 2001
 From: Thibault Charbonnier <thibaultcha@me.com>
 Date: Mon, 6 Jan 2020 17:56:10 -0800
-Subject: [PATCH 5/5] cleanup
+Subject: [PATCH 08/17] cleanup
 
 ---
  src/ngx_http_lua_socket_tcp.c | 24 +++++++++++-------------
  1 file changed, 11 insertions(+), 13 deletions(-)
 
 diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
-index ce8132d3..c4d8d269 100644
+index a7d410c9..bd7cc7ca 100644
 --- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
 +++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
-@@ -1564,6 +1564,7 @@ ngx_http_lua_socket_tcp_check_busy(ngx_http_request_t *r,
+@@ -1555,6 +1555,7 @@ ngx_http_lua_socket_tcp_check_busy(ngx_http_request_t *r,
      return NULL;
  }
-
+ 
 +
  int
  ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
      ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t *sess,
-@@ -1605,7 +1606,7 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+@@ -1596,7 +1597,7 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
      }
-
+ 
      if (u->raw_downstream || u->body_downstream) {
 -        *errmsg = "not supported for downstream";
 +        *errmsg = "not supported for downstream sockets";
          return NGX_ERROR;
      }
-
-@@ -1646,7 +1647,7 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
-
+ 
+@@ -1637,7 +1638,7 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+ 
      if (sess != NULL) {
          if (ngx_ssl_set_session(c, sess) != NGX_OK) {
 -            *errmsg = "lua tls set session failed";
 +            *errmsg = "tls set session failed";
              return NGX_ERROR;
          }
-
-@@ -1669,13 +1670,13 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+ 
+@@ -1660,13 +1661,13 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
          x509 = sk_X509_value(chain, 0);
          if (x509 == NULL) {
              ERR_clear_error();
@@ -889,15 +1010,15 @@ index ce8132d3..c4d8d269 100644
 +            *errmsg = "tls fetch client certificate from chain failed";
              return NGX_ERROR;
          }
-
+ 
          if (SSL_use_certificate(ssl_conn, x509) == 0) {
              ERR_clear_error();
 -            *errmsg = "lua tls set client certificate failed";
 +            *errmsg = "tls set client certificate failed";
              return NGX_ERROR;
          }
-
-@@ -1685,21 +1686,21 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+ 
+@@ -1676,21 +1677,21 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
              x509 = sk_X509_value(chain, i);
              if (x509 == NULL) {
                  ERR_clear_error();
@@ -907,7 +1028,7 @@ index ce8132d3..c4d8d269 100644
 +                          "chain failed";
                  return NGX_ERROR;
              }
-
+ 
              if (SSL_add1_chain_cert(ssl_conn, x509) == 0) {
                  ERR_clear_error();
 -                *errmsg = "lua tls set client intermediate certificate failed";
@@ -915,7 +1036,7 @@ index ce8132d3..c4d8d269 100644
                  return NGX_ERROR;
              }
          }
-
+ 
          if (SSL_use_PrivateKey(ssl_conn, pkey) == 0) {
              ERR_clear_error();
 -            *errmsg = "lua ssl set client private key failed";
@@ -923,16 +1044,16 @@ index ce8132d3..c4d8d269 100644
              return NGX_ERROR;
          }
      }
-@@ -1718,7 +1719,7 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+@@ -1709,7 +1710,7 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
          }
-
+ 
  #else
 -        *errmsg = "OpenSSL has no SNI support";
 +        *errmsg = "no TLS extension support";
          return NGX_ERROR;
  #endif
      }
-@@ -1761,7 +1762,6 @@ new_ssl_name:
+@@ -1752,7 +1753,6 @@ new_ssl_name:
              u->ssl_name.data = ngx_alloc(server_name->len, ngx_cycle->log);
              if (u->ssl_name.data == NULL) {
                  u->ssl_name.len = 0;
@@ -940,30 +1061,494 @@ index ce8132d3..c4d8d269 100644
                  *errmsg = "no memory";
                  return NGX_ERROR;
              }
-@@ -1782,7 +1782,7 @@ new_ssl_name:
+@@ -1773,7 +1773,7 @@ new_ssl_name:
      rc = ngx_ssl_handshake(c);
-
+ 
      ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
 -                   "ngx_ssl_handshake returned %d", rc);
 +                   "ngx_ssl_handshake returned: %d", rc);
-
+ 
      if (rc == NGX_AGAIN) {
          if (c->write->timer_set) {
-@@ -1814,7 +1814,6 @@ new_ssl_name:
-
+@@ -1805,7 +1805,6 @@ new_ssl_name:
+ 
      if (rc == NGX_ERROR) {
          *errmsg = u->error_ret;
 -
          return NGX_ERROR;
      }
-
-@@ -1928,7 +1927,6 @@ failed:
+ 
+@@ -1919,7 +1918,6 @@ failed:
  }
-
-
+ 
+ 
 -
  int
  ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(ngx_http_request_t *r,
      ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t **sess,
---
-2.26.2
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 0bcf4d1a955db9218e8b0e50685c1d0de8c90b9a Mon Sep 17 00:00:00 2001
+From: Datong Sun <datong.sun@konghq.com>
+Date: Tue, 24 Nov 2020 01:49:28 -0800
+Subject: [PATCH 09/17] fixed style according to @spacewander's review
+
+---
+ src/ngx_http_lua_socket_tcp.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index bd7cc7ca..1aa37627 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -1536,15 +1536,15 @@ static const char *
+ ngx_http_lua_socket_tcp_check_busy(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, unsigned int ops)
+ {
+-    if (ops & SOCKET_OP_CONNECT && u->conn_waiting) {
++    if ((ops & SOCKET_OP_CONNECT) && u->conn_waiting) {
+         return "socket busy connecting";
+     }
+ 
+-    if (ops & SOCKET_OP_READ && u->read_waiting) {
++    if ((ops & SOCKET_OP_READ) && u->read_waiting) {
+         return "socket busy reading";
+     }
+ 
+-    if (ops & SOCKET_OP_WRITE
++    if ((ops & SOCKET_OP_WRITE)
+         && (u->write_waiting
+             || (u->raw_downstream
+                 && (r->connection->buffered & NGX_HTTP_LOWLEVEL_BUFFERED))))
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 9b010940f77bbd486c1192eed23af7c35baf4cdb Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Fri, 21 Jan 2022 13:42:06 +0800
+Subject: [PATCH 10/17] resize tcp_socket_metatable to 7
+
+---
+ src/ngx_http_lua_socket_tcp.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index 1aa37627..7cdc45c4 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -160,6 +160,8 @@ enum {
+     SOCKET_CONNECT_TIMEOUT_INDEX = 2,
+     SOCKET_SEND_TIMEOUT_INDEX = 4,
+     SOCKET_READ_TIMEOUT_INDEX = 5,
++    SOCKET_CLIENT_CERT_INDEX = 6,
++    SOCKET_CLIENT_KEY_INDEX = 7,
+ };
+ 
+ 
+@@ -424,7 +426,7 @@ ngx_http_lua_socket_tcp(lua_State *L)
+ 
+     ngx_http_lua_check_context(L, ctx, NGX_HTTP_LUA_CONTEXT_YIELDABLE);
+ 
+-    lua_createtable(L, 5 /* narr */, 1 /* nrec */);
++    lua_createtable(L, 7 /* narr */, 1 /* nrec */);
+     lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
+                           tcp_socket_metatable_key));
+     lua_rawget(L, LUA_REGISTRYINDEX);
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 36245613be1031b22b0e6b2eec398dac288fe9a5 Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Fri, 21 Jan 2022 14:12:13 +0800
+Subject: [PATCH 11/17] change errms tls to ssl
+
+---
+ src/ngx_http_lua_socket_tcp.c | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index 7cdc45c4..af986364 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -1574,7 +1574,7 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+     X509                    *x509;
+ 
+     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+-                   "lua tcp socket tls handshake");
++                   "lua tcp socket ssl handshake");
+ 
+     if (u == NULL
+         || u->peer.connection == NULL
+@@ -1640,12 +1640,12 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+ 
+     if (sess != NULL) {
+         if (ngx_ssl_set_session(c, sess) != NGX_OK) {
+-            *errmsg = "tls set session failed";
++            *errmsg = "ssl set session failed";
+             return NGX_ERROR;
+         }
+ 
+         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+-                       "lua tls set session: %p", sess);
++                       "lua ssl set session: %p", sess);
+ 
+     } else {
+         u->ssl_session_reuse = enable_session_reuse;
+@@ -1663,13 +1663,13 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+         x509 = sk_X509_value(chain, 0);
+         if (x509 == NULL) {
+             ERR_clear_error();
+-            *errmsg = "tls fetch client certificate from chain failed";
++            *errmsg = "ssl fetch client certificate from chain failed";
+             return NGX_ERROR;
+         }
+ 
+         if (SSL_use_certificate(ssl_conn, x509) == 0) {
+             ERR_clear_error();
+-            *errmsg = "tls set client certificate failed";
++            *errmsg = "ssl set client certificate failed";
+             return NGX_ERROR;
+         }
+ 
+@@ -1679,28 +1679,28 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+             x509 = sk_X509_value(chain, i);
+             if (x509 == NULL) {
+                 ERR_clear_error();
+-                *errmsg = "tls fetch client intermediate certificate from "
++                *errmsg = "ssl fetch client intermediate certificate from "
+                           "chain failed";
+                 return NGX_ERROR;
+             }
+ 
+             if (SSL_add1_chain_cert(ssl_conn, x509) == 0) {
+                 ERR_clear_error();
+-                *errmsg = "tls set client intermediate certificate failed";
++                *errmsg = "ssl set client intermediate certificate failed";
+                 return NGX_ERROR;
+             }
+         }
+ 
+         if (SSL_use_PrivateKey(ssl_conn, pkey) == 0) {
+             ERR_clear_error();
+-            *errmsg = "tls set client private key failed";
++            *errmsg = "ssl set client private key failed";
+             return NGX_ERROR;
+         }
+     }
+ 
+     if (server_name != NULL && server_name->data != NULL) {
+         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+-                       "lua tls server name: \"%V\"", server_name);
++                       "lua ssl server name: \"%V\"", server_name);
+ 
+ #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
+         if (SSL_set_tlsext_host_name(c->ssl->connection,
+@@ -1926,7 +1926,7 @@ ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(ngx_http_request_t *r,
+     const char **errmsg, int *openssl_error_code)
+ {
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+-                   "lua cosocket get TLS handshake result for upstream: %p", u);
++                   "lua cosocket get SSL handshake result for upstream: %p", u);
+ 
+     if (u->error_ret != NULL) {
+         *errmsg = u->error_ret;
+@@ -1962,7 +1962,7 @@ ngx_http_lua_tls_handshake_retval_handler(ngx_http_request_t *r,
+         u->ssl_session_ret = ssl_session;
+ 
+         ngx_log_debug1(NGX_LOG_DEBUG_HTTP, c->log, 0,
+-                       "lua tls save session: %p", ssl_session);
++                       "lua ssl save session: %p", ssl_session);
+     }
+ 
+     return 0;
+@@ -1973,7 +1973,7 @@ void
+ ngx_http_lua_ffi_tls_free_session(ngx_ssl_session_t *sess)
+ {
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+-                   "lua tls free session: %p", sess);
++                   "lua ssl free session: %p", sess);
+ 
+     ngx_ssl_free_session(sess);
+ }
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 1f12b89485da6b7ac5dd23810bf094f214dc324e Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Fri, 21 Jan 2022 14:38:49 +0800
+Subject: [PATCH 12/17] rename function name from tls to ssl
+
+---
+ src/ngx_http_lua_socket_tcp.c | 28 ++++++++++++++--------------
+ 1 file changed, 14 insertions(+), 14 deletions(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index af986364..76e98597 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -22,8 +22,8 @@
+ static int ngx_http_lua_socket_tcp(lua_State *L);
+ static int ngx_http_lua_socket_tcp_connect(lua_State *L);
+ #if (NGX_HTTP_SSL)
+-static void ngx_http_lua_tls_handshake_handler(ngx_connection_t *c);
+-static int ngx_http_lua_tls_handshake_retval_handler(ngx_http_request_t *r,
++static void ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c);
++static int ngx_http_lua_ssl_handshake_retval_handler(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L);
+ #endif
+ static int ngx_http_lua_socket_tcp_receive(lua_State *L);
+@@ -1559,7 +1559,7 @@ ngx_http_lua_socket_tcp_check_busy(ngx_http_request_t *r,
+ 
+ 
+ int
+-ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
++ngx_http_lua_ffi_socket_tcp_sslhandshake(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t *sess,
+     int enable_session_reuse, ngx_str_t *server_name, int verify,
+     int ocsp_status_req, STACK_OF(X509) *chain, EVP_PKEY *pkey,
+@@ -1614,7 +1614,7 @@ ngx_http_lua_ffi_socket_tcp_tlshandshake(ngx_http_request_t *r,
+ 
+         u->ssl_session_reuse = enable_session_reuse;
+ 
+-        (void) ngx_http_lua_tls_handshake_retval_handler(r, u, NULL);
++        (void) ngx_http_lua_ssl_handshake_retval_handler(r, u, NULL);
+ 
+         return NGX_OK;
+     }
+@@ -1785,13 +1785,13 @@ new_ssl_name:
+         ngx_add_timer(c->read, u->connect_timeout);
+ 
+         u->conn_waiting = 1;
+-        u->write_prepare_retvals = ngx_http_lua_tls_handshake_retval_handler;
++        u->write_prepare_retvals = ngx_http_lua_ssl_handshake_retval_handler;
+ 
+         ngx_http_lua_cleanup_pending_operation(coctx);
+         coctx->cleanup = ngx_http_lua_coctx_cleanup;
+         coctx->data = u;
+ 
+-        c->ssl->handler = ngx_http_lua_tls_handshake_handler;
++        c->ssl->handler = ngx_http_lua_ssl_handshake_handler;
+ 
+         if (ctx->entered_content_phase) {
+             r->write_event_handler = ngx_http_lua_content_wev_handler;
+@@ -1803,7 +1803,7 @@ new_ssl_name:
+         return NGX_AGAIN;
+     }
+ 
+-    ngx_http_lua_tls_handshake_handler(c);
++    ngx_http_lua_ssl_handshake_handler(c);
+ 
+     if (rc == NGX_ERROR) {
+         *errmsg = u->error_ret;
+@@ -1815,7 +1815,7 @@ new_ssl_name:
+ 
+ 
+ static void
+-ngx_http_lua_tls_handshake_handler(ngx_connection_t *c)
++ngx_http_lua_ssl_handshake_handler(ngx_connection_t *c)
+ {
+     int                          waiting;
+     ngx_int_t                    rc;
+@@ -1860,7 +1860,7 @@ ngx_http_lua_tls_handshake_handler(ngx_connection_t *c)
+ 
+                 llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+                 if (llcf->log_socket_errors) {
+-                    ngx_log_error(NGX_LOG_ERR, dc->log, 0, "lua tls "
++                    ngx_log_error(NGX_LOG_ERR, dc->log, 0, "lua ssl "
+                                   "certificate verify error: (%d: %s)",
+                                   rc, u->error_ret);
+                 }
+@@ -1877,7 +1877,7 @@ ngx_http_lua_tls_handshake_handler(ngx_connection_t *c)
+ 
+                 llcf = ngx_http_get_module_loc_conf(r, ngx_http_lua_module);
+                 if (llcf->log_socket_errors) {
+-                    ngx_log_error(NGX_LOG_ERR, dc->log, 0, "lua tls "
++                    ngx_log_error(NGX_LOG_ERR, dc->log, 0, "lua ssl "
+                                   "certificate does not match host \"%V\"",
+                                   &u->ssl_name);
+                 }
+@@ -1892,7 +1892,7 @@ ngx_http_lua_tls_handshake_handler(ngx_connection_t *c)
+             ngx_http_lua_socket_handle_conn_success(r, u);
+ 
+         } else {
+-            (void) ngx_http_lua_tls_handshake_retval_handler(r, u, NULL);
++            (void) ngx_http_lua_ssl_handshake_retval_handler(r, u, NULL);
+         }
+ 
+         if (waiting) {
+@@ -1921,7 +1921,7 @@ failed:
+ 
+ 
+ int
+-ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(ngx_http_request_t *r,
++ngx_http_lua_ffi_socket_tcp_get_sslhandshake_result(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, ngx_ssl_session_t **sess,
+     const char **errmsg, int *openssl_error_code)
+ {
+@@ -1942,7 +1942,7 @@ ngx_http_lua_ffi_socket_tcp_get_tlshandshake_result(ngx_http_request_t *r,
+ 
+ 
+ static int
+-ngx_http_lua_tls_handshake_retval_handler(ngx_http_request_t *r,
++ngx_http_lua_ssl_handshake_retval_handler(ngx_http_request_t *r,
+     ngx_http_lua_socket_tcp_upstream_t *u, lua_State *L)
+ {
+     ngx_connection_t            *c;
+@@ -1970,7 +1970,7 @@ ngx_http_lua_tls_handshake_retval_handler(ngx_http_request_t *r,
+ 
+ 
+ void
+-ngx_http_lua_ffi_tls_free_session(ngx_ssl_session_t *sess)
++ngx_http_lua_ffi_ssl_free_session(ngx_ssl_session_t *sess)
+ {
+     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, ngx_cycle->log, 0,
+                    "lua ssl free session: %p", sess);
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 84242561aa54ffed3bfab433cfef6f7797e01a47 Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Fri, 21 Jan 2022 14:46:38 +0800
+Subject: [PATCH 13/17] rename to SOCKET_CLIENT_PRIV_INDEX
+
+---
+ src/ngx_http_lua_socket_tcp.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index 76e98597..90da45fc 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -160,8 +160,8 @@ enum {
+     SOCKET_CONNECT_TIMEOUT_INDEX = 2,
+     SOCKET_SEND_TIMEOUT_INDEX = 4,
+     SOCKET_READ_TIMEOUT_INDEX = 5,
+-    SOCKET_CLIENT_CERT_INDEX = 6,
+-    SOCKET_CLIENT_KEY_INDEX = 7,
++    SOCKET_CLIENT_CERT_INDEX  = 6,
++    SOCKET_CLIENT_PRIV_INDEX  = 7,
+ };
+ 
+ 
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 555166646c525167f9e1e5bb81b6cb100a4834f9 Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Fri, 21 Jan 2022 14:49:18 +0800
+Subject: [PATCH 14/17] rename to SOCKET_CLIENT_PKEY_INDEX
+
+---
+ src/ngx_http_lua_socket_tcp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index 90da45fc..494486de 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -161,7 +161,7 @@ enum {
+     SOCKET_SEND_TIMEOUT_INDEX = 4,
+     SOCKET_READ_TIMEOUT_INDEX = 5,
+     SOCKET_CLIENT_CERT_INDEX  = 6,
+-    SOCKET_CLIENT_PRIV_INDEX  = 7,
++    SOCKET_CLIENT_PKEY_INDEX  = 7,
+ };
+ 
+ 
+-- 
+2.32.0 (Apple Git-132)
+
+
+From e9b54c43c05b064b831fe67d0e0aaff45b2ec505 Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Fri, 21 Jan 2022 17:17:09 +0800
+Subject: [PATCH 15/17] need not to change tcp_socket_metatable
+
+---
+ src/ngx_http_lua_socket_tcp.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index 494486de..152d8cbd 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -160,8 +160,6 @@ enum {
+     SOCKET_CONNECT_TIMEOUT_INDEX = 2,
+     SOCKET_SEND_TIMEOUT_INDEX = 4,
+     SOCKET_READ_TIMEOUT_INDEX = 5,
+-    SOCKET_CLIENT_CERT_INDEX  = 6,
+-    SOCKET_CLIENT_PKEY_INDEX  = 7,
+ };
+ 
+ 
+@@ -426,7 +424,7 @@ ngx_http_lua_socket_tcp(lua_State *L)
+ 
+     ngx_http_lua_check_context(L, ctx, NGX_HTTP_LUA_CONTEXT_YIELDABLE);
+ 
+-    lua_createtable(L, 7 /* narr */, 1 /* nrec */);
++    lua_createtable(L, 5 /* narr */, 1 /* nrec */);
+     lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
+                           tcp_socket_metatable_key));
+     lua_rawget(L, LUA_REGISTRYINDEX);
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 6c47356ddc327a8692260bd6f43ea67cf2787a73 Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Wed, 26 Jan 2022 19:55:29 +0800
+Subject: [PATCH 16/17] increase nrec to 3 in the socket object
+
+---
+ src/ngx_http_lua_socket_tcp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index 152d8cbd..8d71f8b4 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -424,7 +424,7 @@ ngx_http_lua_socket_tcp(lua_State *L)
+ 
+     ngx_http_lua_check_context(L, ctx, NGX_HTTP_LUA_CONTEXT_YIELDABLE);
+ 
+-    lua_createtable(L, 5 /* narr */, 1 /* nrec */);
++    lua_createtable(L, 5 /* narr */, 3 /* nrec */);
+     lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
+                           tcp_socket_metatable_key));
+     lua_rawget(L, LUA_REGISTRYINDEX);
+-- 
+2.32.0 (Apple Git-132)
+
+
+From 1d538552c7629310d850d4360408ddb555afcbcc Mon Sep 17 00:00:00 2001
+From: chronolaw <chrono_cpp@me.com>
+Date: Sat, 29 Jan 2022 09:18:52 +0800
+Subject: [PATCH 17/17] change tcp_socket_metatable nrec to 15
+
+---
+ src/ngx_http_lua_socket_tcp.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+index 8d71f8b4..5dcdef0e 100644
+--- a/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
++++ b/ngx_lua-0.10.20/src/ngx_http_lua_socket_tcp.c
+@@ -312,7 +312,7 @@ ngx_http_lua_inject_socket_tcp_api(ngx_log_t *log, lua_State *L)
+     /* {{{tcp object metatable */
+     lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
+                           tcp_socket_metatable_key));
+-    lua_createtable(L, 0 /* narr */, 14 /* nrec */);
++    lua_createtable(L, 0 /* narr */, 15 /* nrec */);
+ 
+     lua_pushcfunction(L, ngx_http_lua_socket_tcp_connect);
+     lua_setfield(L, -2, "connect");
+-- 
+2.32.0 (Apple Git-132)
+


### PR DESCRIPTION
This updates the mTLS patches for `ngx_lua` and `lua-resty-core`, to reflect the latest commits [here](https://github.com/openresty/lua-nginx-module/pull/1602) and [here](https://github.com/openresty/lua-resty-core/pull/278).

This is provisional for now as further updates may be made.