### PR TITLE
chore(boringssl) use gcc - FT-2342

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -523,10 +523,6 @@ main() {
 
         mkdir -p build
         pushd build
-          CC="/usr/bin/clang -fPIE" \
-          CXX="/usr/bin/clang++ -fPIE" \
-          CPP=/usr/bin/clang-cpp \
-          LD=/usr/bin/ld.lld \
           cmake -GNinja -DBUILD_SHARED_LIBS=1 -DFIPS=1  ..
           ninja
         popd #build


### PR DESCRIPTION
Use gcc instead of clang.