### PR TITLE
fix(group): adjust Kong group ownership to be root owned

### DIFF
--- a/after-install.sh
+++ b/after-install.sh
@@ -17,7 +17,7 @@ create_user() {
   FILES="${FILES} /usr/local/share/lua/"
 
   for FILE in ${FILES}; do
-    chown -R kong:kong ${FILE}
+    chown -R kong:root ${FILE}
     chmod -R g=u ${FILE}
   done
 

--- a/after-install.sh
+++ b/after-install.sh
@@ -17,8 +17,8 @@ create_user() {
   FILES="${FILES} /usr/local/share/lua/"
 
   for FILE in ${FILES}; do
-    chown -R kong:root ${FILE}
-    chmod -R g=u ${FILE}
+    chown -R root:kong ${FILE}
+    chmod -R g=u,g-w ${FILE}
   done
 
   return 0

--- a/fpm-entrypoint.sh
+++ b/fpm-entrypoint.sh
@@ -3,10 +3,12 @@
 set -o errexit
 
 cd /tmp/build
+chgrp root -R /tmp/build/*
+chmod -R g=u /tmp/build/*
 
 FPM_PARAMS=""
 if [ "$PACKAGE_TYPE" == "deb" ]; then
-  FPM_PARAMS="-d libpcre3 -d perl -d zlib1g-dev"
+  FPM_PARAMS="-d libpcre3 -d perl -d zlib1g-dev --deb-use-file-permissions"
   OUTPUT_FILE_SUFFIX=".${RESTY_IMAGE_TAG}"
 elif [ "$PACKAGE_TYPE" == "rpm" ]; then
   FPM_PARAMS="-d pcre -d perl -d perl-Time-HiRes -d zlib -d zlib-devel"

--- a/fpm-entrypoint.sh
+++ b/fpm-entrypoint.sh
@@ -3,8 +3,8 @@
 set -o errexit
 
 cd /tmp/build
-chgrp root -R /tmp/build/*
-chmod -R g=u /tmp/build/*
+chown -R root:kong /tmp/build/{,.??}*
+chmod -R g=u,g-w /tmp/build/{,.??}*
 
 FPM_PARAMS=""
 if [ "$PACKAGE_TYPE" == "deb" ]; then


### PR DESCRIPTION
related: https://github.com/Kong/docker-kong/pull/546

This changes ownership of Kong installed files from the current `kong:kong` to `kong:root` such that kong isn't able to rewrite it's own code

~could this be considered a breaking change?~

hold merging this until 3.0