### PR TITLE
fix(logrotate) add `delaycompress` option to fix zip compression error

### DIFF
--- a/kong.logrotate
+++ b/kong.logrotate
@@ -3,6 +3,7 @@
   daily
   missingok
   compress
+  delaycompress
   notifempty
   sharedscripts
   postrotate


### PR DESCRIPTION
Fix FTI-3240.