### PR TITLE
feat(openresty) bundle Kong/lua-resty-websocket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ KONG_GMP_VERSION ?= `grep KONG_GMP_VERSION $(KONG_SOURCE_LOCATION)/.requirements
 KONG_NETTLE_VERSION ?= `grep KONG_NETTLE_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 KONG_NGINX_MODULE ?= `grep KONG_NGINX_MODULE $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_LMDB ?= `grep RESTY_LMDB $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
+RESTY_WEBSOCKET ?= `grep RESTY_WEBSOCKET $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 LIBYAML_VERSION ?= `grep LIBYAML_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 OPENRESTY_PATCHES ?= 1
 DOCKER_KONG_VERSION = 'master'
@@ -109,6 +110,7 @@ debug:
 	@echo ${DEBUG}
 	@echo ${KONG_NGINX_MODULE}
 	@echo ${RESTY_LMDB}
+	@echo ${RESTY_WEBSOCKET}
 
 setup-ci: setup-build
 
@@ -166,6 +168,7 @@ else
 	--build-arg KONG_NETTLE_VERSION=$(KONG_NETTLE_VERSION) \
 	--build-arg KONG_NGINX_MODULE=$(KONG_NGINX_MODULE) \
 	--build-arg RESTY_LMDB=$(RESTY_LMDB) \
+	--build-arg RESTY_WEBSOCKET=$(RESTY_WEBSOCKET) \
 	--build-arg OPENRESTY_PATCHES=$(OPENRESTY_PATCHES) \
 	--build-arg DEBUG=$(DEBUG) \
 	-t $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)-$(DOCKER_OPENRESTY_SUFFIX) . )

--- a/build-openresty.sh
+++ b/build-openresty.sh
@@ -44,6 +44,12 @@ then
   RESTY_LMDB=0
 fi
 
+if [ -z "$RESTY_WEBSOCKET" ]
+then
+  RESTY_WEBSOCKET=0
+fi
+
+
 LUAROCKS_PREFIX=/usr/local \
 LUAROCKS_DESTDIR=/tmp/build \
 OPENRESTY_PREFIX=/usr/local/openresty \
@@ -57,6 +63,7 @@ EDITION=$EDITION \
 --openresty $RESTY_VERSION \
 --openssl $RESTY_OPENSSL_VERSION \
 --resty-lmdb $RESTY_LMDB \
+--resty-websocket $RESTY_WEBSOCKET \
 --luarocks $RESTY_LUAROCKS_VERSION \
 --kong-nginx-module $KONG_NGINX_MODULE \
 --pcre $RESTY_PCRE_VERSION \

--- a/dockerfiles/Dockerfile.openresty
+++ b/dockerfiles/Dockerfile.openresty
@@ -81,6 +81,9 @@ LABEL resty_luarocks_version="${RESTY_LUAROCKS_VERSION}"
 ARG RESTY_LMDB=0
 LABEL resty_lmdb="${RESTY_LMDB}"
 
+ARG RESTY_WEBSOCKET=0
+LABEL resty_websocket="${RESTY_WEBSOCKET}"
+
 COPY openresty-build-tools /tmp/openresty-build-tools
 COPY openresty-patches /tmp/openresty-patches
 COPY build-openresty.sh /tmp/build-openresty.sh

--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -15,6 +15,7 @@ FORCE=0
 OPENRESTY_PATCHES=$OPENRESTY_PATCHES
 KONG_NGINX_MODULE=master
 RESTY_LMDB=master
+RESTY_WEBSOCKET=${RESTY_WEBSOCKET:-0}
 DEBUG=0
 NPROC=
 OS=
@@ -94,6 +95,10 @@ main() {
         ;;
       --no-resty-lmdb)
         RESTY_LMDB=0
+        shift 1
+        ;;
+      --resty-websocket)
+        RESTY_WEBSOCKET=$2
         shift 1
         ;;
       -f|--force)
@@ -280,6 +285,23 @@ main() {
             rm -f lua-resty-dns-0.21.tar.gz
           popd
         fi
+
+        if [[ $RESTY_WEBSOCKET != 0 ]]; then
+          pushd openresty-$OPENRESTY_VER/bundle
+            if ! rm -rf lua-resty-websocket-*; then
+              fatal "Failed to find/remove upstream lua-resty-websocket component"
+            fi
+            mkdir "lua-resty-websocket-${RESTY_WEBSOCKET}"
+            notice "Downloading Kong/lua-resty-websocket $RESTY_WEBSOCKET"
+            curl -sSL \
+              -o lua-resty-websocket.tar.gz \
+              "https://github.com/Kong/lua-resty-websocket/archive/refs/tags/${RESTY_WEBSOCKET}.tar.gz"
+            tar -xzf lua-resty-websocket.tar.gz \
+              -C "lua-resty-websocket-${RESTY_WEBSOCKET}" \
+              --strip-components 1
+            rm -f lua-resty-websocket.tar.gz
+          popd
+        fi
       fi
     fi
 
@@ -388,6 +410,16 @@ main() {
       pushd $OPENRESTY_DOWNLOAD/bundle
         if [ ! -f .patch_applied ]; then
           for patch_file in $(ls -1 $OPENRESTY_PATCHES_DIR/patches/$OPENRESTY_VER/*.patch); do
+            # any existing patch files will surely conflict with our fork of
+            # lua-resty-websocket, so skip them if bundling Kong/lua-resty-websocket
+            if
+              [[ $RESTY_WEBSOCKET != 0 ]] &&
+              [[ "$(basename "$patch_file")" = lua-resty-websocket-* ]]
+            then
+              notice "Skipping lua-resty-websocket patch: $patch_file"
+              continue
+            fi
+
             notice "Applying OpenResty patch $patch_file"
             patch -p1 < $patch_file \
               || fatal "failed to apply patch: $patch_file"
@@ -811,6 +843,9 @@ show_usage() {
   echo ""
   echo "      --resty-lmdb <branch>          Specify a lua-resty-lmdb branch to use when patching and compiling."
   echo "                                     (Defaults to \"master\")"
+  echo ""
+  echo "      --resty-websocket <tag>        Specify a Kong/lua-resty-websocket tag to install in place of the"
+  echo "                                     bundled version of lua-resty-websocket (Defaults to \"$RESTY_WEBSOCKET\")"
   echo ""
   echo "      --luarocks <luarocks_ver>      Version of LuaRocks to build, such as 3.1.2. If absent, LuaRocks"
   echo "                                     will not be built."

--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -97,6 +97,10 @@ docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ldd /
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ldd /usr/local/openresty/bin/openresty | grep -q /usr/local/openresty/luajit/lib/libluajit-5.1.so.2"
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "/usr/local/openresty/bin/openresty -V 2>&1 | grep /work/pcre-${RESTY_PCRE_VERSION}"
 
+# lua-resty-websocket library (sourced from OpenResty or Kong/lua-resty-websocket)
+docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ls -l /usr/local/openresty/lualib/resty/websocket/*.lua"
+docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "grep _VERSION /usr/local/openresty/lualib/resty/websocket/*.lua"
+
 # luarocks
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "luarocks --version | grep -q ${RESTY_LUAROCKS_VERSION}"
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "luarocks config | grep -q /usr/local/openresty/luajit/bin/luajit"


### PR DESCRIPTION
This adds [Kong's fork of lua-resty-websocket](https://github.com/Kong/lua-resty-websocket]) to kong-ngx-build.

Main differences between our fork and the current lua-resty-websocket release (v0.08) are:

* mTLS support for `client:connect()` - this has been [merged](https://github.com/openresty/lua-resty-websocket/pull/72) but is not yet released
* other `client:connect()`  enhancements - features needed by Kong that we'll attempt to upstream as best we can ([example](https://github.com/openresty/lua-resty-websocket/pull/76))

Full diff:
https://github.com/openresty/lua-resty-websocket/compare/v0.08...Kong:master

This affects CE and EE as both rely on the mTLS functionality. Up until now this has been achieved by way of [patch file](https://github.com/Kong/kong-build-tools/blob/886101503c3bc96577ada04124bd812260701016/openresty-patches/patches/1.19.9.1/lua-resty-websocket-0.08_01-client-mtls.patch).

---

Feedback wanted:

* This fork and our existing lua-resty-websocket patch files must be mutually-exclusive. An earlier iteration of this code simply removed the relevant patch file(s). This is nice and straightforward but not backwards compatible. The current iteration is fully opt-in and attempts to skip `lua-resty-websocket` patch files when using our fork, so it's backwards-compatible but.... eh, feels messy. How much concern is backwards compatibility: any/some/none?
* I've tried to be as defensive as possible here, but any ideas for how to do additional testing/sanity-checking?