### PR TITLE
feat(LuaJIT) change the LuaJIT version format to something like `LuaJIT 2.1-20220411`

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -585,6 +585,15 @@ main() {
 
     pushd $OPENRESTY_DOWNLOAD
       if [ ! -f Makefile ]; then
+
+        pushd bundle
+          lj_dir=$(ls -d LuaJIT*)
+          lj_release_date=$(echo ${lj_dir} | sed -e 's/LuaJIT-[[:digit:]]\+.[[:digit:]]\+-\([[:digit:]]\+\)/\1/')
+          lj_version_tag="LuaJIT\ 2.1.0-${lj_release_date}"
+        popd
+
+        notice "Building LuaJIT with version string $lj_version_tag"
+
         OPENRESTY_OPTS=(
           "--prefix=$OPENRESTY_PREFIX"
           "--with-pcre-jit"
@@ -593,6 +602,7 @@ main() {
           "--with-http_stub_status_module"
           "--with-http_v2_module"
           "--without-http_encrypted_session_module"
+          "--with-luajit-xcflags='-DLUAJIT_VERSION=\\\"${lj_version_tag}\\\"'"
           "-j$NPROC"
         )
 

--- a/openresty-patches/patches/1.19.9.1/LuaJIT-2.1-20210510_03_patch_macro_luajit_version.patch
+++ b/openresty-patches/patches/1.19.9.1/LuaJIT-2.1-20210510_03_patch_macro_luajit_version.patch
@@ -1,0 +1,27 @@
+From f53c8fa441f4233b9a3f19fcd870207fe8795456 Mon Sep 17 00:00:00 2001
+From: Qi <add_sp@outlook.com>
+Date: Wed, 25 May 2022 18:35:08 +0800
+Subject: [PATCH] Patch macro `LUAJIT_VERSION`
+
+---
+ src/luajit.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/LuaJIT-2.1-20210510/src/luajit.h b/LuaJIT-2.1-20210510/src/luajit.h
+index a4d33001..e35f4e7e 100644
+--- a/LuaJIT-2.1-20210510/src/luajit.h
++++ b/LuaJIT-2.1-20210510/src/luajit.h
+@@ -32,7 +32,9 @@
+
+ #define OPENRESTY_LUAJIT
+
++#ifndef LUAJIT_VERSION
+ #define LUAJIT_VERSION		"LuaJIT 2.1.0-beta3"
++#endif
+ #define LUAJIT_VERSION_NUM	20100  /* Version 2.1.0 = 02.01.00. */
+ #define LUAJIT_VERSION_SYM	luaJIT_version_2_1_0_beta3
+ #define LUAJIT_COPYRIGHT	"Copyright (C) 2005-2022 Mike Pall"
+--
+2.34.1
+
+

--- a/openresty-patches/patches/1.21.4.1/LuaJIT-2.1-20210510_01_patch_macro_luajit_version.patch
+++ b/openresty-patches/patches/1.21.4.1/LuaJIT-2.1-20210510_01_patch_macro_luajit_version.patch
@@ -1,0 +1,27 @@
+From f53c8fa441f4233b9a3f19fcd870207fe8795456 Mon Sep 17 00:00:00 2001
+From: Qi <add_sp@outlook.com>
+Date: Wed, 25 May 2022 18:35:08 +0800
+Subject: [PATCH] Patch macro `LUAJIT_VERSION`
+
+---
+ src/luajit.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/LuaJIT-2.1-20220411/src/luajit.h b/LuaJIT-2.1-20220411/src/luajit.h
+index a4d33001..e35f4e7e 100644
+--- a/LuaJIT-2.1-20220411/src/luajit.h
++++ b/LuaJIT-2.1-20220411/src/luajit.h
+@@ -32,7 +32,9 @@
+
+ #define OPENRESTY_LUAJIT
+
++#ifndef LUAJIT_VERSION
+ #define LUAJIT_VERSION		"LuaJIT 2.1.0-beta3"
++#endif
+ #define LUAJIT_VERSION_NUM	20100  /* Version 2.1.0 = 02.01.00. */
+ #define LUAJIT_VERSION_SYM	luaJIT_version_2_1_0_beta3
+ #define LUAJIT_COPYRIGHT	"Copyright (C) 2005-2022 Mike Pall"
+--
+2.34.1
+
+

--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -97,6 +97,8 @@ docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ldd /
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ldd /usr/local/openresty/bin/openresty | grep -q /usr/local/kong/lib/libcrypto.so.1.1"
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ldd /usr/local/openresty/bin/openresty | grep -q /usr/local/openresty/luajit/lib/libluajit-5.1.so.2"
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "/usr/local/openresty/bin/openresty -V 2>&1 | grep /work/pcre-${RESTY_PCRE_VERSION}"
+docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "/usr/local/openresty/bin/resty -e 'print(jit.version)' | grep -q 'LuaJIT[[:space:]][[:digit:]]\+.[[:digit:]]\+.[[:digit:]]\+-[[:digit:]]\{8\}'"
+
 
 # lua-resty-websocket library (sourced from OpenResty or Kong/lua-resty-websocket)
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ls -l /usr/local/openresty/lualib/resty/websocket/*.lua"


### PR DESCRIPTION
This is one solution to fix `FT-2807`. Another solution is https://github.com/Kong/kong-build-tools/pull/466 .

```
$ resty -e "print(jit.version)"
LuaJIT 2.1.0-20210510
```