### PR TITLE
FTI-3275 partially revert d66b848a b50c155b

### DIFF
--- a/after-install.sh
+++ b/after-install.sh
@@ -20,7 +20,7 @@ create_user() {
   FILES="${FILES} /usr/local/share/lua/"
 
   for FILE in ${FILES}; do
-    chown -R kong:kong ${FILE}
+    chown -R kong:root ${FILE}
     chmod -R g=u ${FILE}
   done
 

--- a/after-install.sh
+++ b/after-install.sh
@@ -20,7 +20,7 @@ create_user() {
   FILES="${FILES} /usr/local/share/lua/"
 
   for FILE in ${FILES}; do
-    chown -R kong:root ${FILE}
+    chown -R kong:kong ${FILE}
     chmod -R g=u ${FILE}
   done
 

--- a/after-install.sh
+++ b/after-install.sh
@@ -1,5 +1,6 @@
 create_user() {
-  useradd -U -m -s /bin/sh kong
+  groupadd -f kong
+  useradd -g kong -ms /bin/sh kong
 
   FILES=""
   FILES="${FILES} /etc/kong/"
@@ -9,7 +10,9 @@ create_user() {
   FILES="${FILES} /usr/local/bin/lua2json"
   FILES="${FILES} /usr/local/bin/luarocks"
   FILES="${FILES} /usr/local/bin/luarocks-admin"
+  FILES="${FILES} /usr/local/bin/openapi2kong"
   FILES="${FILES} /usr/local/etc/luarocks/"
+  FILES="${FILES} /usr/local/etc/passwdqc/"
   FILES="${FILES} /usr/local/kong/"
   FILES="${FILES} /usr/local/lib/lua/"
   FILES="${FILES} /usr/local/lib/luarocks/"

--- a/fpm-entrypoint.sh
+++ b/fpm-entrypoint.sh
@@ -16,7 +16,7 @@ elif [ "$PACKAGE_TYPE" == "rpm" ]; then
   fi
   if [ "$RESTY_IMAGE_BASE" == "amazonlinux" ]; then
     OUTPUT_FILE_SUFFIX=".aws"
-    FPM_PARAMS="$FPM_PARAMS -d /usr/sbin/useradd"
+    FPM_PARAMS="$FPM_PARAMS -d /usr/sbin/useradd -d /usr/sbin/groupadd"
   fi
   if [ "$RESTY_IMAGE_BASE" == "centos" ]; then
     OUTPUT_FILE_SUFFIX=".el${RESTY_IMAGE_TAG}"

--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -23,7 +23,7 @@ if [[ "$PACKAGE_TYPE" == "deb" ]]; then
 fi
 
 if [[ "$RESTY_IMAGE_BASE" != "alpine" ]]; then
-  # These files should have 'kong:root' ownership
+  # These files should have 'kong:kong' ownership
   files=(
     "/etc/kong/"
     "/usr/local/bin/json2lua"
@@ -41,8 +41,8 @@ if [[ "$RESTY_IMAGE_BASE" != "alpine" ]]; then
   )
 
   for file in "${files[@]}"; do
-    # Check if the 'chown -R kong:root' ownership changes worked
-    docker exec ${USE_TTY} -e file=$file user-validation-tests /bin/bash -c '[ $(find $file -exec stat -c "%U:%G" {} \; | grep -vc "kong:root") == "0" ]'
+    # Check if the 'chown -R kong:kong' ownership changes worked
+    docker exec ${USE_TTY} -e file=$file user-validation-tests /bin/bash -c '[ $(find $file -exec stat -c "%U:%G" {} \; | grep -vc "kong:kong") == "0" ]'
 
     # Check if the 'chmod g=u -R' permission changes worked
     docker exec ${USE_TTY} -e file=$file user-validation-tests /bin/bash -c '[ $(find $file -exec stat -c "%a" {} \; | grep -Evc "^(.)\1") == "0" ]'

--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -23,7 +23,7 @@ if [[ "$PACKAGE_TYPE" == "deb" ]]; then
 fi
 
 if [[ "$RESTY_IMAGE_BASE" != "alpine" ]]; then
-  # These files should have 'kong:kong' ownership
+  # These files should have 'kong:root' ownership
   files=(
     "/etc/kong/"
     "/usr/local/bin/json2lua"
@@ -41,8 +41,8 @@ if [[ "$RESTY_IMAGE_BASE" != "alpine" ]]; then
   )
 
   for file in "${files[@]}"; do
-    # Check if the 'chown -R kong:kong' ownership changes worked
-    docker exec ${USE_TTY} -e file=$file user-validation-tests /bin/bash -c '[ $(find $file -exec stat -c "%U:%G" {} \; | grep -vc "kong:kong") == "0" ]'
+    # Check if the 'chown -R kong:root' ownership changes worked
+    docker exec ${USE_TTY} -e file=$file user-validation-tests /bin/bash -c '[ $(find $file -exec stat -c "%U:%G" {} \; | grep -vc "kong:root") == "0" ]'
 
     # Check if the 'chmod g=u -R' permission changes worked
     docker exec ${USE_TTY} -e file=$file user-validation-tests /bin/bash -c '[ $(find $file -exec stat -c "%a" {} \; | grep -Evc "^(.)\1") == "0" ]'


### PR DESCRIPTION
We revert the `kong:kong` to `kong:root` change  at https://github.com/Kong/kong-build-tools/pull/457 and https://github.com/Kong/kong-build-tools/pull/463 to keep consistent with https://github.com/Kong/kong-distributions/pull/783.

The suggested files permission should be left alone as `root:root`. We should do in separate PRs to do this.