### PR TITLE
feat(releases): add capability of doing ee internal releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         DEBUG = 0
     }
     options {
-        retry(1)
+        retry(2)
         timeout(time: 120, unit: 'MINUTES')
     }
     stages {

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ EDITION?=`grep EDITION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print
 KONG_LICENSE?="ASL 2.0"
 
 KONG_PACKAGE_NAME ?= `grep KONG_PACKAGE_NAME $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
+OFFICIAL_RELEASE ?= true
 
 PACKAGE_CONFLICTS ?= `grep PACKAGE_CONFLICTS $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 PACKAGE_PROVIDES ?= `grep PACKAGE_PROVIDES $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
@@ -128,6 +129,10 @@ debug:
 	@echo ${KONG_NGINX_MODULE}
 	@echo ${RESTY_LMDB}
 	@echo ${RESTY_WEBSOCKET}
+	@echo ${KONG_VERSION}
+	@echo ${KONG_PACKAGE_NAME}
+	@echo ${OFFICIAL_RELEASE}
+	
 
 setup-ci: setup-build
 
@@ -301,6 +306,7 @@ release-kong: test
 	DOCKER_RELEASE_REPOSITORY=$(DOCKER_RELEASE_REPOSITORY) \
 	DOCKER_LABEL_CREATED=`date -u +'%Y-%m-%dT%H:%M:%SZ'` \
 	DOCKER_LABEL_REVISION=$(KONG_SHA) \
+	OFFICIAL_RELEASE=$(OFFICIAL_RELEASE) \
 	./release-kong.sh
 ifeq ($(BUILDX),true)
 	@DOCKER_MACHINE_NAME=$(shell docker-machine env $(DOCKER_MACHINE_ARM64_NAME) | grep 'DOCKER_MACHINE_NAME=".*"' | cut -d\" -f2) \
@@ -321,6 +327,7 @@ ifeq ($(BUILDX),true)
 	RELEASE_DOCKER_ONLY=$(RELEASE_DOCKER_ONLY) \
 	DOCKER_LABEL_CREATED=`date -u +'%Y-%m-%dT%H:%M:%SZ'` \
 	DOCKER_LABEL_REVISION=$(KONG_SHA) \
+	OFFICIAL_RELEASE=$(OFFICIAL_RELEASE) \
 	./release-kong.sh
 endif
 

--- a/release-kong.sh
+++ b/release-kong.sh
@@ -112,10 +112,10 @@ function push_package() {
   if [[ "$EDITION" == "enterprise" ]]; then
     release_args="$release_args --enterprise"
     # enterprise pre-releases go to `/internal/`
-    if [[ "$OFFICIAL_RELEASE" == "false" ]]; then
-      release_args="$release_args --internal"
-    else
+    if [[ "$OFFICIAL_RELEASE" == "true" ]]; then
       release_args="$release_args --publish"
+    else
+      release_args="$release_args --internal"
     fi
   else
     release_args="$release_args --publish"

--- a/release-kong.sh
+++ b/release-kong.sh
@@ -108,9 +108,15 @@ function push_package() {
 
   set -x
 
-  local release_args="--package-type gateway --publish"
+  local release_args="--package-type gateway"
   if [[ "$EDITION" == "enterprise" ]]; then
     release_args="$release_args --enterprise"
+  fi
+  
+  if [[ "$OFFICIAL_RELEASE" == "false" ]]; then
+    release_args="$release_args --internal"
+  else
+    release_args="$release_args --publish"
   fi
 
   eval $(docker-machine env -u) # release-scripts do not need to run within the arm64 box

--- a/release-kong.sh
+++ b/release-kong.sh
@@ -111,10 +111,12 @@ function push_package() {
   local release_args="--package-type gateway"
   if [[ "$EDITION" == "enterprise" ]]; then
     release_args="$release_args --enterprise"
-  fi
-  
-  if [[ "$OFFICIAL_RELEASE" == "false" ]]; then
-    release_args="$release_args --internal"
+    # enterprise pre-releases go to `/internal/`
+    if [[ "$OFFICIAL_RELEASE" == "false" ]]; then
+      release_args="$release_args --internal"
+    else
+      release_args="$release_args --publish"
+    fi
   else
     release_args="$release_args --publish"
   fi


### PR DESCRIPTION
While testing https://github.com/Kong/kong-ee/pull/3093 it was found we haven't captured the way Kong Enterprise expects internal releases to work.

**Kong Enterprise pre-releases go to the production release environment in a private location**

1. When the git tag has a `-` the Kong EE Makefile sets `OFFICIAL_RELEASE=false` ( https://github.com/Kong/kong-ee/blob/a65e715f0aa128202dd98246006522d8dd52f294/Makefile#L65-L68 )
2. If we're ENTERPRISE=true && OFFICIAL_RELEASE=false set the release flag to `--internal` ( https://github.com/Kong/kong-build-tools/blob/d9d008e2c8212c0cf76402693597e396325025c7/release-kong.sh#L112-L117 )

**Kong CE pre-releases go to the staging release environment in a public location**

1. Kong CE Jenkinsfile sets PULP_HOST_STAGE and PULP_HOST_PROD whereas EE's Jenkinsfile sets both to production ( https://github.com/Kong/kong/blob/master/Jenkinsfile#L13-L16 )
2. Kong-build-tools will use PULP_HOST_STAG if the KONG_VERSION is a prerelease version ( https://github.com/Kong/kong-build-tools/blob/d9d008e2c8212c0cf76402693597e396325025c7/release-kong.sh#L12-L21 )

**Kong Enterprise per commit releases release a docker alpine container to kong/kong-gateway-internal**

1. We override the release repository in the kong-ee Jenkinsfile ( https://github.com/Kong/kong-ee/blob/a65e715f0aa128202dd98246006522d8dd52f294/Jenkinsfile#L57 ) whose default lives in [.requirements](https://github.com/Kong/kong-ee/blob/a65e715f0aa128202dd98246006522d8dd52f294/.requirements#L9)

**Kong CE per commit releases release a docker alpine container to kong/kong**

1. This is the default so it simply follow the regular release process then exist early before pushing packages