### PR TITLE
fix(hybrid): fix the path to the wrpc file

### DIFF
--- a/build-kong.sh
+++ b/build-kong.sh
@@ -24,8 +24,7 @@ export PATH=$PATH:/usr/local/openresty/luajit/bin
 /usr/local/openresty/bin/openresty -v
 
 pushd /kong
-  cp -r kong/include/kong /tmp/build/usr/local/kong/lib/ || true
-
+  cp -r kong/include /tmp/build/usr/local/kong/lib/ || true
   ROCKSPEC_VERSION=`basename /kong/kong-*.rockspec` \
     && ROCKSPEC_VERSION=${ROCKSPEC_VERSION%.*} \
     && ROCKSPEC_VERSION=${ROCKSPEC_VERSION#"kong-"}


### PR DESCRIPTION
tested as follows:
```
make package-kong
dpkg -c output/kong-2.8.0.20.04.amd64.deb | grep wrpc.proto
-rw-r----- 0/0            6271 2022-05-23 13:21 ./usr/local/kong/lib/include/wrpc/wrpc.proto
```

a backwards compatible tests would be a quick smoke of running hybrid Kong that I don't have the bandwidth to take on but it's on the todo list