### PR TITLE
feat(make) improve debug output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ endif
 
 DOCKER_REPOSITORY?=kong/kong-build-tools
 
-# this prints out variables defined within this Makefile by filterting out
+# this prints out variables defined within this Makefile by filtering out
 # from pre-existing ones ($VARS_OLD), then echoing both the unexpanded variable
 # value (within single quotes) and the expanded variable value (without quotes)
 #

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ DOCKER_REPOSITORY?=kong/kong-build-tools
 # from pre-existing ones ($VARS_OLD), then echoing both the unexpanded variable
 # value (within single quotes) and the expanded variable value (without quotes)
 #
-# variables' whos value does not expand, are only printed once ("uniq"-ed )
+# variables whose value does not expand are only printed once ("uniq"-ed )
 debug:
 	@$(foreach v, \
 		$(sort $(filter-out $(VARS_OLD) VARS_OLD,$(.VARIABLES))), \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 $(info starting make in kong-build-tools)
 
+VARS_OLD := $(.VARIABLES)
+
 .PHONY: test build-kong
 .DEFAULT_GOAL := package-kong
 
@@ -116,23 +118,19 @@ endif
 
 DOCKER_REPOSITORY?=kong/kong-build-tools
 
+# this prints out variables defined within this Makefile by filterting out
+# from pre-existing ones ($VARS_OLD), then echoing both the unexpanded variable
+# value (within single quotes) and the expanded variable value (without quotes)
+#
+# variables' whos value does not expand, are only printed once ("uniq"-ed )
 debug:
-	@echo ${DOCKER_REPOSITORY}
-	@echo ${CACHE}
-	@echo ${BUILDX}
-	@echo ${UPDATE_CACHE}
-	@echo ${CACHE_COMMAND}
-	@echo ${UPDATE_CACHE_COMMAND}
-	@echo ${DOCKER_COMMAND}
-	@echo ${BUILDX_INFO}
-	@echo ${DEBUG}
-	@echo ${KONG_NGINX_MODULE}
-	@echo ${RESTY_LMDB}
-	@echo ${RESTY_WEBSOCKET}
-	@echo ${KONG_VERSION}
-	@echo ${KONG_PACKAGE_NAME}
-	@echo ${OFFICIAL_RELEASE}
-	
+	@$(foreach v, \
+		$(sort $(filter-out $(VARS_OLD) VARS_OLD,$(.VARIABLES))), \
+		( \
+			echo '$(v) = $($(v))' ; echo \
+			      $(v) = $($(v)) ;  \
+		) | uniq ; \
+	)
 
 setup-ci: setup-build
 


### PR DESCRIPTION
The notable exception to this are the Makefile vars like: `DOCKER_MACHINE_ARM64_NAME?=docker-machine-arm64-${USER}` that utilize curly braces-- those will only appear "expanded".

Previously:
```
$ gmake debug
starting make in kong-build-tools
kong/kong-build-tools
true
false
true
docker pull
docker push
docker build --progress=auto --build-arg BUILDPLATFORM=x/amd64

0
0.2.1
master

2.8.0
kong
true
```

Now:
```
$ gmake debug
starting make in kong-build-tools
.SHELLSTATUS = 0
BUILDX = false
BUILDX_INFO =
BUILDX_INFO =
BUILD_TOOLS_SHA = $(git rev-parse --short HEAD)
BUILD_TOOLS_SHA = acec034
CACHE = true
CACHE_BUSTER = 0
DEBUG = 0
DOCKER_BASE_SUFFIX = $(git rev-parse --short HEAD)0
DOCKER_BASE_SUFFIX = acec0340
DOCKER_BUILD_PROGRESS = auto
DOCKER_KONG_SUFFIX = $(git rev-parse --short HEAD)10-`echo "$PWD/../kong/"/kong-*.rockspec | sed s,.*/,, | cut -d- -f2`-$(git --git-dir="$PWD/../kong/"/.git rev-parse --short HEAD)-0
DOCKER_KONG_SUFFIX = acec03410-2.8.0-2e9846eb3-0
DOCKER_KONG_VERSION = master
DOCKER_MACHINE_ARM64_NAME = docker-machine-arm64-<redacted>
DOCKER_OPENRESTY_SUFFIX = $(git rev-parse --short HEAD)-$(find kong/distribution -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum  | cut -d  -f 1)10-0
DOCKER_OPENRESTY_SUFFIX = acec034-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85510-0
DOCKER_RELEASE_REPOSITORY = `grep DOCKER_RELEASE_REPOSITORY "$PWD/../kong/"/.requirements | awk -F"=" {print }`
DOCKER_RELEASE_REPOSITORY =
DOCKER_REPOSITORY = kong/kong-build-tools
DOCKER_TEST_SUFFIX = $(git rev-parse --short HEAD)-0-$(git --git-dir="$PWD/../kong/"/.git rev-parse --short HEAD)-0
DOCKER_TEST_SUFFIX = acec034-0-2e9846eb3-0
EDITION = `grep EDITION "$PWD/../kong/"/.requirements | awk -F"=" {print }`
EDITION =
ENABLE_LJBC = `grep ENABLE_LJBC "$PWD/../kong/"/.requirements | awk -F"=" {print }`
ENABLE_LJBC =
KONG_GMP_VERSION = `grep KONG_GMP_VERSION "$PWD/../kong/"/.requirements | awk -F"=" {print }`
KONG_GMP_VERSION =
KONG_GO_PLUGINSERVER_VERSION = `grep KONG_GO_PLUGINSERVER_VERSION "$PWD/../kong/"/.requirements | awk -F"=" {print }`
KONG_GO_PLUGINSERVER_VERSION =
KONG_LICENSE = "ASL 2.0"
KONG_LICENSE = ASL 2.0
KONG_NETTLE_VERSION = `grep KONG_NETTLE_VERSION "$PWD/../kong/"/.requirements | awk -F"=" {print }`
KONG_NETTLE_VERSION =
KONG_NGINX_MODULE = `grep KONG_NGINX_MODULE "$PWD/../kong/"/.requirements | awk -F"=" {print }`
KONG_NGINX_MODULE = 0.2.1
KONG_PACKAGE_NAME = `grep KONG_PACKAGE_NAME "$PWD/../kong/"/.requirements | awk -F"=" {print }`
KONG_PACKAGE_NAME = kong
KONG_SHA = $(git --git-dir="$PWD/../kong/"/.git rev-parse --short HEAD)
KONG_SHA = 2e9846eb3
KONG_SOURCE_LOCATION = "$PWD/../kong/"
KONG_SOURCE_LOCATION = /Users/<redacted>/Development/github.com/kong/kong-build-tools/../kong/
KONG_TEST_CONTAINER_NAME = kong-tests
KONG_TEST_CONTAINER_TAG = 5000/kong-ubuntu-20.04
KONG_TEST_IMAGE_NAME = localhost:5000/kong-ubuntu-20.04
KONG_VERSION = `echo "$PWD/../kong/"/kong-*.rockspec | sed s,.*/,, | cut -d- -f2`
KONG_VERSION = 2.8.0
LIBYAML_VERSION = `grep ^LIBYAML_VERSION "$PWD/../kong/"/.requirements | awk -F"=" {print }`
LIBYAML_VERSION = 0.2.5
OFFICIAL_RELEASE = true
OPENRESTY_PATCHES = 1
PACKAGE_CONFLICTS = `grep PACKAGE_CONFLICTS "$PWD/../kong/"/.requirements | awk -F"=" {print }`
PACKAGE_CONFLICTS =
PACKAGE_PROVIDES = `grep PACKAGE_PROVIDES "$PWD/../kong/"/.requirements | awk -F"=" {print }`
PACKAGE_PROVIDES =
PACKAGE_REPLACES = `grep PACKAGE_REPLACES "$PWD/../kong/"/.requirements | awk -F"=" {print }`
PACKAGE_REPLACES =
PACKAGE_TYPE = deb
RELEASE_DOCKER_ONLY = false
REQUIREMENTS_SHA = $(find kong/distribution -type f -print0 | sort -z | xargs -0 sha256sum | sha256sum  | cut -d  -f 1)
REQUIREMENTS_SHA = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
RESTY_IMAGE_BASE = ubuntu
RESTY_IMAGE_TAG = 20.04
RESTY_LMDB = `grep RESTY_LMDB "$PWD/../kong/"/.requirements | awk -F"=" {print }`
RESTY_LMDB = master
RESTY_LUAROCKS_VERSION = `grep RESTY_LUAROCKS_VERSION "$PWD/../kong/"/.requirements | awk -F"=" {print }`
RESTY_LUAROCKS_VERSION = 3.9.0
RESTY_OPENSSL_VERSION = `grep RESTY_OPENSSL_VERSION "$PWD/../kong/"/.requirements | awk -F"=" {print }`
RESTY_OPENSSL_VERSION = 1.1.1o
RESTY_PCRE_VERSION = `grep RESTY_PCRE_VERSION "$PWD/../kong/"/.requirements | awk -F"=" {print }`
RESTY_PCRE_VERSION = 8.45
RESTY_VERSION = `grep RESTY_VERSION "$PWD/../kong/"/.requirements | awk -F"=" {print }`
RESTY_VERSION = 1.19.9.1
RESTY_WEBSOCKET = `grep RESTY_WEBSOCKET "$PWD/../kong/"/.requirements | awk -F"=" {print }`
RESTY_WEBSOCKET =
ROOT_DIR = /Users/<redacted>/Development/github.com/Kong/kong-build-tools
TEST_ADMIN_PORT = 8001
TEST_ADMIN_PROTOCOL = http://
TEST_ADMIN_URI = http://localhost:8001
TEST_COMPOSE_PATH = "/Users/<redacted>/Development/github.com/kong/kong-build-tools/test/kong-tests-compose.yaml"
TEST_COMPOSE_PATH = /Users/<redacted>/Development/github.com/kong/kong-build-tools/test/kong-tests-compose.yaml
TEST_HOST = localhost
TEST_PROXY_PORT = 8000
TEST_PROXY_PROTOCOL = http://
TEST_PROXY_URI = http://localhost:8000
TEST_SHA = $(git log -1 --pretty=format:"%h" -- /Users/<redacted>/Development/github.com/Kong/kong-build-tools/test/)0
TEST_SHA = 049c6550
UPDATE_CACHE = true
VERBOSE = false
```