### PR TITLE
fix(alpine): alpine needs to specify the arm64 architecture

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,6 +142,10 @@ pipeline {
                             label 'bionic'
                         }
                     }
+                    environment {
+                        AWS_ACCESS_KEY = credentials('AWS_ACCESS_KEY')
+                        AWS_SECRET_ACCESS_KEY = credentials('AWS_SECRET_ACCESS_KEY')
+                    }
                     steps {
                         sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                         sh 'git clone --single-branch --branch ${KONG_SOURCE} https://github.com/Kong/kong.git ${KONG_SOURCE_LOCATION}'

--- a/test/build_container.sh
+++ b/test/build_container.sh
@@ -18,7 +18,7 @@ chmod -R 755 docker-kong/*.sh
 if [ "$RESTY_IMAGE_BASE" == "src" ]; then
   exit 0
 elif [ "$RESTY_IMAGE_BASE" == "alpine" ]; then
-  cp output/*.apk.tar.gz docker-kong/kong.apk.tar.gz
+  cp output/*${ARCHITECTURE}*.apk.tar.gz docker-kong/kong.apk.tar.gz
 elif [ "$PACKAGE_TYPE" == "deb" ]; then
   cp output/*${ARCHITECTURE}*.deb docker-kong/kong.deb
 else


### PR DESCRIPTION
a series of conflating PR reviews led us to accidentally drop tests for the alpine arm asset and then break our ability to run tests when doing multi-architecture alpine builds.

This fixes the CI so it once again tests the alpine arm64 and also the necessary differentiation the build test image requires to distinguish when there's a amd and an arm asset.

Example of the failure: https://internal.builds.konghq.com/blue/organizations/jenkins/kong/detail/master/3/pipeline#step-37-log-2432