### PR TITLE
feat(release): use an explicit environment variable to determine when to push docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             environment {
                 DOCKER_REPOSITORY = "kong/kong-build-tools-private"
                 GITHUB_TOKEN = credentials('github_bot_access_token')
-                KONG_SOURCE = "feat/branch-by-abstraction"
+                KONG_SOURCE = "master"
                 PULP = credentials('PULP')
                 PULP_PASSWORD = "${env.PULP_PSW}"
                 PULP_USERNAME = "${env.PULP_USR}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,9 +53,7 @@ pipeline {
                         sh 'git clone --recursive --single-branch --branch ${KONG_SOURCE} https://github.com/Kong/kong-ee.git ${KONG_SOURCE_LOCATION}'
                         sh 'make RESTY_IMAGE_BASE=amazonlinux RESTY_IMAGE_TAG=2 package-kong test cleanup'
                         sh 'make RESTY_IMAGE_BASE=centos      RESTY_IMAGE_TAG=7 package-kong test cleanup'
-                        sh 'make RESTY_IMAGE_BASE=rockylinux  RESTY_IMAGE_TAG=8 package-kong test cleanup'
                         sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=7 package-kong test cleanup'
-                        sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=8 package-kong test cleanup'
                     }
                 }
                 stage('Kong Enterprise src & Alpine'){
@@ -129,9 +127,7 @@ pipeline {
                         sh 'git clone --single-branch --branch ${KONG_SOURCE} https://github.com/Kong/kong.git ${KONG_SOURCE_LOCATION}'
                         sh 'make RESTY_IMAGE_BASE=amazonlinux RESTY_IMAGE_TAG=2 package-kong test cleanup'
                         sh 'make RESTY_IMAGE_BASE=centos      RESTY_IMAGE_TAG=7 package-kong test cleanup'
-                        sh 'make RESTY_IMAGE_BASE=rockylinux  RESTY_IMAGE_TAG=8 package-kong test cleanup'
                         sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=7 package-kong test cleanup'
-                        sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=8 package-kong test cleanup'
                     }
                 }
                 stage('Kong OSS src & Alpine'){

--- a/release-kong.sh
+++ b/release-kong.sh
@@ -31,7 +31,6 @@ KONG_VERSION=$KONG_VERSION
 
 DOCKER_REPOSITORY="kong/kong"
 DOCKER_REPOSITORY="${DOCKER_RELEASE_REPOSITORY:-kong/kong}"
-DOCKER_TAG="latest"
 
 
 case "$RESTY_IMAGE_BASE" in
@@ -75,21 +74,6 @@ function push_docker_images() {
     -a "$DOCKER_REPOSITORY:$KONG_VERSION" \
        "$DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION"
   docker manifest push "$DOCKER_REPOSITORY:$KONG_VERSION"
-
-  docker tag \
-    "localhost:5000/kong-$RESTY_IMAGE_BASE-$RESTY_IMAGE_TAG" \
-    "$DOCKER_REPOSITORY:$ARCHITECTURE-$DOCKER_TAG"
-
-  echo "FROM $DOCKER_REPOSITORY:$ARCHITECTURE-$DOCKER_TAG" | docker build \
-    --label org.opencontainers.image.version="$KONG_VERSION" \
-    --label org.opencontainers.image.created="$DOCKER_LABEL_CREATED" \
-    --label org.opencontainers.image.revision="$DOCKER_LABEL_REVISION" \
-    -t "$DOCKER_REPOSITORY:$ARCHITECTURE-$DOCKER_TAG" -
-  docker push "$DOCKER_REPOSITORY:$ARCHITECTURE-$DOCKER_TAG"
-
-  docker manifest create -a "$DOCKER_REPOSITORY:$DOCKER_TAG" \
-    "$DOCKER_REPOSITORY:$ARCHITECTURE-$DOCKER_TAG"
-  docker manifest push "$DOCKER_REPOSITORY:$DOCKER_TAG"
 }
 
 

--- a/release-kong.sh
+++ b/release-kong.sh
@@ -123,10 +123,10 @@ function push_package() {
 
 # only push docker images for alpine builds
 # this is for "release per commit" builds
-if [ "$RELEASE_DOCKER" == "true" ]; then
+if [[ "$RELEASE_DOCKER" == "true" ]]; then
   push_docker_images
 
-  if [ "$RELEASE_DOCKER_ONLY" == "true" ]; then
+  if [[ "$RELEASE_DOCKER_ONLY" == "true" ]]; then
     exit 0
   fi
 fi

--- a/release-kong.sh
+++ b/release-kong.sh
@@ -71,9 +71,9 @@ function push_docker_images() {
   docker push "$DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION"
 
   docker manifest create \
-    -a "$DOCKER_REPOSITORY:$KONG_VERSION" \
+    -a "$DOCKER_REPOSITORY:$KONG_VERSION-$RESTY_IMAGE_BASE" \
        "$DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION"
-  docker manifest push "$DOCKER_REPOSITORY:$KONG_VERSION"
+  docker manifest push "$DOCKER_REPOSITORY:$KONG_VERSION-$RESTY_IMAGE_BASE"
 }
 
 
@@ -123,7 +123,7 @@ function push_package() {
 
 # only push docker images for alpine builds
 # this is for "release per commit" builds
-if [ "$RESTY_IMAGE_BASE" == "alpine" ]; then
+if [ "$RELEASE_DOCKER" == "true" ]; then
   push_docker_images
 
   if [ "$RELEASE_DOCKER_ONLY" == "true" ]; then

--- a/test/build_container.sh
+++ b/test/build_container.sh
@@ -28,6 +28,8 @@ fi
 pushd docker-kong
   if [ "$RESTY_IMAGE_BASE" == "rhel" ]; then
     sed -i.bak 's/^FROM .*/FROM 'registry.access.redhat.com\\/ubi${RESTY_IMAGE_TAG}\\/ubi'/' Dockerfile.$PACKAGE_TYPE
+  elif [ "$RESTY_IMAGE_BASE" == "debian" ]; then
+    sed -i.bak 's/^FROM .*/FROM '${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}-slim'/' Dockerfile.$PACKAGE_TYPE
   else
     sed -i.bak 's/^FROM .*/FROM '${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}'/' Dockerfile.$PACKAGE_TYPE
   fi


### PR DESCRIPTION
existing: if alpine we push `kong:x.y.z` and `kong:latest`

new behaviour: if `RELEASE_DOCKER=true` we push `kong:x.y.z-dist`

also when the base image is debian we use a slim debian