### PR TITLE
I have docker-kong checked out locally and on my CDPATH 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,7 +422,7 @@ cleanup: cleanup-tests cleanup-build
 	-rm -rf docker-kong
 	-rm -rf output/*
 	-git submodule deinit -f .
-	-docker rmi $(KONG_TEST_CONTAINER_TAG)
+	-docker rmi $(KONG_TEST_IMAGE_NAME)
 
 update-cache-images:
 	-$(UPDATE_CACHE_COMMAND) $(DOCKER_REPOSITORY):$(PACKAGE_TYPE)-$(DOCKER_BASE_SUFFIX)

--- a/test/build_container.sh
+++ b/test/build_container.sh
@@ -7,6 +7,7 @@ DOCKER_BUILD_ARGS=()
 
 image_id=$(docker image inspect -f '{{.ID}}' "$KONG_TEST_IMAGE_NAME" || true)
 if [ -n "$image_id" ]; then
+  msg_test "Tests image Name: $KONG_TEST_IMAGE_NAME"
   msg_test "Tests image ID: $image_id"
   exit 0;
 fi
@@ -25,7 +26,7 @@ else
   cp output/*.${PACKAGE_TYPE} docker-kong/kong.${PACKAGE_TYPE}
 fi
 
-pushd docker-kong
+pushd ./docker-kong
   if [ "$RESTY_IMAGE_BASE" == "rhel" ]; then
     sed -i.bak 's/^FROM .*/FROM 'registry.access.redhat.com\\/ubi${RESTY_IMAGE_TAG}\\/ubi'/' Dockerfile.$PACKAGE_TYPE
   else
@@ -39,6 +40,7 @@ pushd docker-kong
     "${DOCKER_BUILD_ARGS[@]}"
 
   docker run -t $KONG_TEST_IMAGE_NAME kong version
+  msg_test "Tests image Name: $KONG_TEST_IMAGE_NAME"
 popd
 
 rm -rf docker-kong || true


### PR DESCRIPTION
This caused the `pushd docker-kong` to go to that folder rather than the locally cloned one. I also added some logging I found helpful.