### PR TITLE
feat(cache-from): use docker buildkit cache-from ability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,12 +79,14 @@ else ifeq ($(RESTY_IMAGE_BASE),alpine)
 	BUILDX=true
 endif
 
+DOCKER_BUILDKIT ?= 1
+
 BUILDX_INFO ?= $(shell docker buildx 2>&1 >/dev/null; echo $?)
 
 ifeq ($(BUILDX),false)
-	DOCKER_COMMAND?=DOCKER_BUILDKIT=1 docker build --progress=$(DOCKER_BUILD_PROGRESS) --build-arg BUILDPLATFORM=x/amd64
+	DOCKER_COMMAND?=docker build --progress=$(DOCKER_BUILD_PROGRESS) --build-arg BUILDPLATFORM=x/amd64
 else
-	DOCKER_COMMAND?=DOCKER_BUILDKIT=1 docker buildx build --progress=$(DOCKER_BUILD_PROGRESS) --push --platform="linux/amd64,linux/arm64"
+	DOCKER_COMMAND?=docker buildx build --progress=$(DOCKER_BUILD_PROGRESS) --push --platform="linux/amd64,linux/arm64"
 endif
 
 # Set this to unique value to bust the cache

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ endif
 BUILDX_INFO ?= $(shell docker buildx 2>&1 >/dev/null; echo $?)
 
 ifeq ($(BUILDX),false)
-	DOCKER_COMMAND?=docker build --progress=$(DOCKER_BUILD_PROGRESS) --build-arg BUILDPLATFORM=x/amd64
+	DOCKER_COMMAND?=DOCKER_BUILDKIT=1 docker build --progress=$(DOCKER_BUILD_PROGRESS) --build-arg BUILDPLATFORM=x/amd64
 else
-	DOCKER_COMMAND?=docker buildx build --progress=$(DOCKER_BUILD_PROGRESS) --push --platform="linux/amd64,linux/arm64"
+	DOCKER_COMMAND?=DOCKER_BUILDKIT=1 docker buildx build --progress=$(DOCKER_BUILD_PROGRESS) --push --platform="linux/amd64,linux/arm64"
 endif
 
 # Set this to unique value to bust the cache
@@ -182,6 +182,7 @@ else
 	--build-arg RESTY_PCRE_VERSION=$(RESTY_PCRE_VERSION) \
 	--build-arg PACKAGE_TYPE=$(PACKAGE_TYPE) \
 	--build-arg DOCKER_REPOSITORY=$(DOCKER_REPOSITORY) \
+	--build-arg GITHUB_TOKEN=$(GITHUB_TOKEN) \
 	--build-arg DOCKER_BASE_SUFFIX=$(DOCKER_BASE_SUFFIX) \
 	--build-arg LIBYAML_VERSION=$(LIBYAML_VERSION) \
 	--build-arg EDITION=$(EDITION) \
@@ -191,6 +192,9 @@ else
 	--build-arg RESTY_EVENTS=$(RESTY_EVENTS) \
 	--build-arg OPENRESTY_PATCHES=$(OPENRESTY_PATCHES) \
 	--build-arg DEBUG=$(DEBUG) \
+	--build-arg BUILDKIT_INLINE_CACHE=1 \
+	--cache-from $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE) \
+	--cache-from kong/kong-build-tools:openresty-$(PACKAGE_TYPE) \
 	-t $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)-$(DOCKER_OPENRESTY_SUFFIX) . )
 endif
 
@@ -255,6 +259,7 @@ actual-build-kong: setup-kong-source
 	--build-arg DOCKER_OPENRESTY_SUFFIX=$(DOCKER_OPENRESTY_SUFFIX) \
 	--build-arg GITHUB_TOKEN=$(GITHUB_TOKEN) \
 	--build-arg ENABLE_LJBC=$(ENABLE_LJBC) \
+	--build-arg BUILDKIT_INLINE_CACHE=1 \
 	-t $(DOCKER_REPOSITORY):kong-$(PACKAGE_TYPE)-$(DOCKER_KONG_SUFFIX) . )
 
 kong-test-container: setup-kong-source
@@ -267,6 +272,9 @@ ifneq ($(RESTY_IMAGE_BASE),src)
 	--build-arg KONG_GO_PLUGINSERVER_VERSION=$(KONG_GO_PLUGINSERVER_VERSION) \
 	--build-arg DOCKER_REPOSITORY=$(DOCKER_REPOSITORY) \
 	--build-arg DOCKER_OPENRESTY_SUFFIX=$(DOCKER_OPENRESTY_SUFFIX) \
+	--build-arg BUILDKIT_INLINE_CACHE=1 \
+	--cache-from $(DOCKER_REPOSITORY):test \
+	--cache-from kong/kong-build-tools:test \
 	-t $(DOCKER_REPOSITORY):test-$(DOCKER_TEST_SUFFIX) . )
 	
 	docker tag $(DOCKER_REPOSITORY):test-$(DOCKER_TEST_SUFFIX) $(DOCKER_REPOSITORY):test
@@ -427,7 +435,10 @@ cleanup: cleanup-tests cleanup-build
 	-docker rmi $(KONG_TEST_IMAGE_NAME)
 
 update-cache-images:
-	-$(UPDATE_CACHE_COMMAND) $(DOCKER_REPOSITORY):$(PACKAGE_TYPE)-$(DOCKER_BASE_SUFFIX)
-	-docker tag $(DOCKER_REPOSITORY):$(PACKAGE_TYPE)-$(DOCKER_BASE_SUFFIX) $(DOCKER_REPOSITORY):$(PACKAGE_TYPE) || true
 	-$(UPDATE_CACHE_COMMAND) $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)-$(DOCKER_OPENRESTY_SUFFIX)
+	-docker tag $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)-$(DOCKER_OPENRESTY_SUFFIX) $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)
+	-$(UPDATE_CACHE_COMMAND) $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)
 	-$(UPDATE_CACHE_COMMAND) $(DOCKER_REPOSITORY):kong-$(PACKAGE_TYPE)-$(DOCKER_KONG_SUFFIX)
+	-docker tag $(DOCKER_REPOSITORY):kong-$(PACKAGE_TYPE)-$(DOCKER_KONG_SUFFIX) $(DOCKER_REPOSITORY):kong-$(PACKAGE_TYPE)
+	-$(UPDATE_CACHE_COMMAND) $(DOCKER_REPOSITORY):kong-$(PACKAGE_TYPE)
+	-$(UPDATE_CACHE_COMMAND) $(DOCKER_REPOSITORY):test

--- a/dockerfiles/Dockerfile.openresty
+++ b/dockerfiles/Dockerfile.openresty
@@ -2,7 +2,7 @@ ARG DOCKER_BASE_SUFFIX
 ARG DOCKER_REPOSITORY
 ARG PACKAGE_TYPE
 
-FROM kong/kong-build-tools:$PACKAGE_TYPE-1.5.12
+FROM kong/kong-build-tools:$PACKAGE_TYPE-1.5.15
 
 ARG EDITION="community"
 ENV EDITION $EDITION
@@ -63,3 +63,13 @@ ARG DEBUG=1
 RUN DEBUG="${DEBUG}" /tmp/build-openresty.sh
 
 RUN sed -i 's/\/tmp\/build//' `grep -l -I -r '\/tmp\/build' /tmp/build/` || true
+
+COPY kong /kong
+RUN rm -rf /distribution/*
+
+ARG GITHUB_TOKEN
+
+# Initial part of Dockerfile.kong for cache purposes
+COPY kong/.requirements kong/distribution/ /distribution/
+WORKDIR /distribution
+RUN if [ -f "/distribution/post-install.sh" ] ; then ./post-install.sh; fi


### PR DESCRIPTION
utilize docker buildkit `--cache-from` so we get higher fidelity than our current cache hit which is either the entire image already exists or it does not

Before
![image](https://user-images.githubusercontent.com/697188/173067866-669cdec3-0e52-45e0-af47-c37576a4c35b.png)

After
![image](https://user-images.githubusercontent.com/697188/173067797-872f8427-2686-46a6-8d29-789a17081b88.png)
