### PR TITLE
fix(release): adjust release logic from angular to conventionalCommit

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,13 +3,37 @@
   "tagFormat": "${version}",
   "plugins": [
     ["@semantic-release/commit-analyzer", {
-      "preset": "angular",
+      "preset": "conventionalcommits",
+      "releaseRules": [
+        { "breaking": true,   "release": "major" },
+        { "revert": true,     "release": "patch" },
+        { "type": "build",    "release": "patch" },
+        { "type": "docs",     "release": "patch" },
+        { "type": "feat",     "release": "minor" },
+        { "type": "fix",      "release": "patch" },
+        { "type": "perf",     "release": "patch" },
+        { "type": "refactor", "release": "patch" }
+      ]
       "parserOpts": {
         "headerPattern": '^(\w*)(?:\(([\w\$\.\-\* ]*)\))? (.*)$'
       }
     }],
     ["@semantic-release/release-notes-generator", {
-      "preset": "angular",
+      "preset": "conventionalcommits",
+      "presetConfig": {
+        "types": [
+          { "type": "build",    "section": "Build",       "hidden": false },
+          { "type": "chore",    "section": "Chores",      "hidden": false },
+          { "type": "ci",       "section": "CI/CD",       "hidden": false },
+          { "type": "docs",     "section": "Docs",        "hidden": false },
+          { "type": "feat",     "section": "Features",    "hidden": false },
+          { "type": "fix",      "section": "Bug Fixes",   "hidden": false },
+          { "type": "perf",     "section": "Performance", "hidden": false },
+          { "type": "refactor", "section": "Refactor",    "hidden": false },
+          { "type": "style",    "section": "Code Style",  "hidden": false },
+          { "type": "test",     "section": "Tests",       "hidden": false }
+        ]
+      }
       "parserOpts": {
         "headerPattern": '^(\w*)(?:\(([\w\$\.\-\* ]*)\))? (.*)$'
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,22 +171,21 @@ pipeline {
                 }
             }
         }
-        stage('Release') {
-            agent {
-                node {
-                    label 'bionic'
+        post {
+            success {
+                agent {
+                    node {
+                        label 'bionic'
+                    }
                 }
-            }
-            when {
-                branch 'master'
-            }
-            environment {
-                GITHUB_TOKEN = credentials('github_bot_access_token')
-            }
-            steps {
-                sh 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash'
-                sh '. ~/.nvm/nvm.sh && nvm install lts/*'
-                sh '. ~/.nvm/nvm.sh && npx semantic-release@beta'
+                environment {
+                    GITHUB_TOKEN = credentials('github_bot_access_token')
+                }
+                steps {
+                    sh 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash'
+                    sh '. ~/.nvm/nvm.sh && nvm install lts/*'
+                    sh '. ~/.nvm/nvm.sh && npx semantic-release@beta'
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,6 @@ pipeline {
     }
     options {
         retry(2)
-        timeout(time: 120, unit: 'MINUTES')
     }
     stages {
         stage('Enteprise Test Builds') {
@@ -179,7 +178,7 @@ pipeline {
                 }
             }
             when {
-                triggeredBy 'TimerTrigger'
+                branch 'master'
             }
             environment {
                 GITHUB_TOKEN = credentials('github_bot_access_token')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,21 +171,22 @@ pipeline {
                 }
             }
         }
-        post {
-            success {
-                agent {
-                    node {
-                        label 'bionic'
-                    }
+        stage('Release') {
+            agent {
+                node {
+                    label 'bionic'
                 }
-                environment {
-                    GITHUB_TOKEN = credentials('github_bot_access_token')
-                }
-                steps {
-                    sh 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash'
-                    sh '. ~/.nvm/nvm.sh && nvm install lts/*'
-                    sh '. ~/.nvm/nvm.sh && npx semantic-release@beta'
-                }
+            }
+            when {
+                branch 'master'
+            }
+            environment {
+                GITHUB_TOKEN = credentials('github_bot_access_token')
+            }
+            steps {
+                sh 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash'
+                sh '. ~/.nvm/nvm.sh && nvm install lts/*'
+                sh '. ~/.nvm/nvm.sh && npx semantic-release@beta'
             }
         }
     }


### PR DESCRIPTION
Using the prior art from https://github.com/Kong/template-generic which is in use on we want conventional commit releases not angular and we make our release rules less restrictive.

This also makes the adjustment so every commit to master runs the release logic