### PR TITLE
chore(ci): use github actions for release purposes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+---
+name: BRelease
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches:
+    - master
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Release
+      id: release
+      uses: ahmadnassri/action-semantic-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -13,7 +13,7 @@
         { "type": "fix",      "release": "patch" },
         { "type": "perf",     "release": "patch" },
         { "type": "refactor", "release": "patch" }
-      ]
+      ],
       "parserOpts": {
         "headerPattern": '^(\w*)(?:\(([\w\$\.\-\* ]*)\))? (.*)$'
       }
@@ -33,7 +33,7 @@
           { "type": "style",    "section": "Code Style",  "hidden": false },
           { "type": "test",     "section": "Tests",       "hidden": false }
         ]
-      }
+      },
       "parserOpts": {
         "headerPattern": '^(\w*)(?:\(([\w\$\.\-\* ]*)\))? (.*)$'
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,23 +171,5 @@ pipeline {
                 }
             }
         }
-        stage('Release') {
-            agent {
-                node {
-                    label 'bionic'
-                }
-            }
-            when {
-                branch 'master'
-            }
-            environment {
-                GITHUB_TOKEN = credentials('github_bot_access_token')
-            }
-            steps {
-                sh 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash'
-                sh '. ~/.nvm/nvm.sh && nvm install lts/*'
-                sh '. ~/.nvm/nvm.sh && npx semantic-release@beta'
-            }
-        }
     }
 }


### PR DESCRIPTION
Tested as viable on my fork https://github.com/hutchic/kong-build-tools/runs/6834563325?check_suite_focus=true

Changing the commit analyzer might lead to an unexpected jump in our semver but I think that's OK