### PR TITLE
chore(ci): add kong-ci-cache-key

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -12,7 +12,8 @@
         { "type": "feat",     "release": "minor" },
         { "type": "fix",      "release": "patch" },
         { "type": "perf",     "release": "patch" },
-        { "type": "refactor", "release": "patch" }
+        { "type": "refactor", "release": "patch" },
+        { "type": "chore", "release": "patch" }
       ]
     }],
     ["@semantic-release/release-notes-generator", {

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+$(info starting make in kong-build-tools)
+
 VARS_OLD := $(.VARIABLES)
 
 .PHONY: test build-kong

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-$(info starting make in kong-build-tools)
-
 VARS_OLD := $(.VARIABLES)
 
 .PHONY: test build-kong
@@ -250,6 +248,9 @@ build-kong:
 else
 build-kong: actual-build-kong
 endif
+
+kong-ci-cache-key:
+	@echo "CACHE_KEY=$(DOCKER_OPENRESTY_SUFFIX)"
 
 actual-build-kong: setup-kong-source
 	touch id_rsa.private


### PR DESCRIPTION
We desire the ability to have a more local faster cache in places. To avoid side effects of overlapping cache's that may or may not hit / refresh on different requirements let's share a central unified authoritative cache key from one place.

An example of the cache key in use https://github.com/Kong/kong-ee/pull/3322/commits/866f3b18ff9b949b0b733e755c920ca8ccfc6b95