### PR TITLE
fix(logrotate): add `su kong kong` to avoid logrotate warnings

### DIFF
--- a/kong.logrotate
+++ b/kong.logrotate
@@ -1,4 +1,5 @@
 /usr/local/kong/logs/*.log {
+  su kong kong
   rotate 14
   daily
   missingok


### PR DESCRIPTION
The rpm installation of Kong 2.2.0 start using a self-created kong user as the o
wner for /usr/local/kong/logs instead of system nobody. But the directory's perm
issions allow writes by a group that isn’t root are not permitted by Logrotate,
or you may see the error as "insecure permissions".

The idea of this PR is to fix the warning errors when running logrotate.

FTI-3197