### PR TITLE
fix(logrotate) set "su kong kong" permissions

### DIFF
--- a/kong.logrotate
+++ b/kong.logrotate
@@ -1,3 +1,5 @@
+su kong kong
+
 /usr/local/kong/logs/*.log {
   rotate 14
   daily


### PR DESCRIPTION
The default logrotate isn't able to, for example, access the logs:

```text
error: skipping "/usr/local/kong/logs/access.log" because parent
directory has insecure permissions (It's world writable or writable by
group which is not "root") Set "su" directive in config file to tell
logrotate which user/group should be used for rotation.
```

This change fixes it.