### PR TITLE
fix(rhel): allow RESTY_IMAGE_TAG to be 2+ digits

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,10 +50,10 @@ pipeline {
                         sh 'while /bin/bash -c "ps aux | grep [a]pt-get"; do sleep 5; done'
                         sh 'curl https://raw.githubusercontent.com/Kong/kong/master/scripts/setup-ci.sh | bash'
                         sh 'git clone --recursive --single-branch --branch ${KONG_SOURCE} https://github.com/Kong/kong-ee.git ${KONG_SOURCE_LOCATION}'
-                        sh 'make RESTY_IMAGE_BASE=amazonlinux RESTY_IMAGE_TAG=2 package-kong test cleanup'
-                        sh 'make RESTY_IMAGE_BASE=centos      RESTY_IMAGE_TAG=7 package-kong test cleanup'
-                        sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=7 package-kong test cleanup'
-                        sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=8 package-kong test cleanup'
+                        sh 'make RESTY_IMAGE_BASE=amazonlinux RESTY_IMAGE_TAG=2   package-kong test cleanup'
+                        sh 'make RESTY_IMAGE_BASE=centos      RESTY_IMAGE_TAG=7   package-kong test cleanup'
+                        sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=7.9 package-kong test cleanup'
+                        sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=8.6 package-kong test cleanup'
                     }
                 }
                 stage('Kong Enterprise src & Alpine'){
@@ -125,10 +125,10 @@ pipeline {
                     steps {
                         sh 'echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin || true'
                         sh 'git clone --single-branch --branch ${KONG_SOURCE} https://github.com/Kong/kong.git ${KONG_SOURCE_LOCATION}'
-                        sh 'make RESTY_IMAGE_BASE=amazonlinux RESTY_IMAGE_TAG=2 package-kong test cleanup'
-                        sh 'make RESTY_IMAGE_BASE=centos      RESTY_IMAGE_TAG=7 package-kong test cleanup'
-                        sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=7 package-kong test cleanup'
-                        sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=8 package-kong test cleanup'
+                        sh 'make RESTY_IMAGE_BASE=amazonlinux RESTY_IMAGE_TAG=2   package-kong test cleanup'
+                        sh 'make RESTY_IMAGE_BASE=centos      RESTY_IMAGE_TAG=7   package-kong test cleanup'
+                        sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=7.9 package-kong test cleanup'
+                        sh 'make RESTY_IMAGE_BASE=rhel        RESTY_IMAGE_TAG=8.6 package-kong test cleanup'
                     }
                 }
                 stage('Kong OSS src & Alpine'){

--- a/test/build_container.sh
+++ b/test/build_container.sh
@@ -27,7 +27,11 @@ else
 fi
 
 pushd ./docker-kong
-  if [ "$RESTY_IMAGE_BASE" == "rhel" ]; then
+  if \
+    [ "$RESTY_IMAGE_BASE" == 'rhel' ] || \
+    [[ "$RESTY_IMAGE_BASE" == *'/ubi'* ]] || \
+    [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]] \
+  ; then
     major="${RESTY_IMAGE_TAG%%.*}"
 
     sed -i.bak "s|^FROM .*|FROM registry.access.redhat.com/ubi${major}/ubi:${RESTY_IMAGE_TAG}|" Dockerfile.$PACKAGE_TYPE

--- a/test/build_container.sh
+++ b/test/build_container.sh
@@ -28,7 +28,9 @@ fi
 
 pushd ./docker-kong
   if [ "$RESTY_IMAGE_BASE" == "rhel" ]; then
-    sed -i.bak 's/^FROM .*/FROM 'registry.access.redhat.com\\/ubi${RESTY_IMAGE_TAG}\\/ubi'/' Dockerfile.$PACKAGE_TYPE
+    major="${RESTY_IMAGE_TAG%%.*}"
+
+    sed -i.bak "s|^FROM .*|FROM registry.access.redhat.com/ubi${major}/ubi:${RESTY_IMAGE_TAG}|" Dockerfile.$PACKAGE_TYPE
   elif [ "$RESTY_IMAGE_BASE" == "debian" ]; then
     sed -i.bak 's/^FROM .*/FROM '${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}-slim'/' Dockerfile.$PACKAGE_TYPE
   else

--- a/test/build_container.sh
+++ b/test/build_container.sh
@@ -30,8 +30,8 @@ pushd ./docker-kong
   if \
     [ "$RESTY_IMAGE_BASE" == 'rhel' ] || \
     [[ "$RESTY_IMAGE_BASE" == *'/ubi'* ]] || \
-    [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]] \
-  ; then
+    [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]]
+  then
     major="${RESTY_IMAGE_TAG%%.*}"
 
     sed -i.bak "s|^FROM .*|FROM registry.access.redhat.com/ubi${major}/ubi:${RESTY_IMAGE_TAG}|" Dockerfile.$PACKAGE_TYPE

--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -5,7 +5,8 @@ if \
   [[ "$RESTY_IMAGE_BASE" == *'/ubi'* ]] || \
   [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]] \
 ; then
-  docker run -d --name user-validation-tests --rm -e KONG_DATABASE=off -v $PWD:/src registry.access.redhat.com/ubi${RESTY_IMAGE_TAG}/ubi tail -f /dev/null
+  major="${RESTY_IMAGE_TAG%%.*}"
+  docker run -d --name user-validation-tests --rm -e KONG_DATABASE=off -v $PWD:/src registry.access.redhat.com/ubi${major}/ubi tail -f /dev/null
 else
   docker run -d --name user-validation-tests --rm -e KONG_DATABASE=off -v $PWD:/src ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG} tail -f /dev/null
 fi

--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -3,8 +3,8 @@ set -x
 if \
   [ "$RESTY_IMAGE_BASE" == 'rhel' ] || \
   [[ "$RESTY_IMAGE_BASE" == *'/ubi'* ]] || \
-  [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]] \
-; then
+  [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]]
+then
   major="${RESTY_IMAGE_TAG%%.*}"
   docker run -d --name user-validation-tests --rm -e KONG_DATABASE=off -v $PWD:/src registry.access.redhat.com/ubi${major}/ubi tail -f /dev/null
 else

--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -1,6 +1,10 @@
 set -x
 
-if [[ "$RESTY_IMAGE_BASE" == "rhel" ]]; then
+if \
+  [ "$RESTY_IMAGE_BASE" == 'rhel' ] || \
+  [[ "$RESTY_IMAGE_BASE" == *'/ubi'* ]] || \
+  [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]] \
+; then
   docker run -d --name user-validation-tests --rm -e KONG_DATABASE=off -v $PWD:/src registry.access.redhat.com/ubi${RESTY_IMAGE_TAG}/ubi tail -f /dev/null
 else
   docker run -d --name user-validation-tests --rm -e KONG_DATABASE=off -v $PWD:/src ${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG} tail -f /dev/null
@@ -55,7 +59,12 @@ if [[ "$RESTY_IMAGE_BASE" != "alpine" ]]; then
   docker exec ${USE_TTY} user-validation-tests /bin/bash -c "test -d /home/kong/"
   docker exec ${USE_TTY} user-validation-tests /bin/bash -c "cat /etc/passwd | grep kong | grep -q /bin/sh"
 
-  if [[ "$RESTY_IMAGE_BASE" == "amazonlinux" || "$RESTY_IMAGE_BASE" == "rhel" ]]; then
+  if \
+    [[ "$RESTY_IMAGE_BASE" == "amazonlinux" ]] || \
+    [ "$RESTY_IMAGE_BASE" == 'rhel' ] || \
+    [[ "$RESTY_IMAGE_BASE" == *'/ubi'* ]] || \
+    [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]] \
+  ; then
     # Needed to run `su`
     docker exec ${USE_TTY} user-validation-tests /bin/bash -c "yum install -y util-linux"
 


### PR DESCRIPTION
Full RedHat family versions are classically 2 digits (`7.9`, `8.6`, `9.0`) and the ubi docker container image tags conform to that standard:
- [registry.access.redhat.com/ubi7/ubi-minimal:7.9](https://catalog.redhat.com/software/containers/ubi7/ubi-minimal/5c3594f7dd19c775cddfa777?tag=all)
- [registry.access.redhat.com/ubi7/ubi-minimal:8.6](https://catalog.redhat.com/software/containers/ubi8/5c647760bed8bd28d0e38f9f?tag=all)
- [redhat/ubi9:9.0](https://hub.docker.com/r/redhat/ubi9/tags)

Crucially, they do NOT offer "major-only" floating tags (e.g. `*:9`).

This PR just splits out the major version of the `RESTY_IMAGE_TAG`.