### PR TITLE
feat(enterprise): Restoring the 4th digit of the Kong EE version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ KONG_TEST_CONTAINER_TAG?=5000/kong-$(RESTY_IMAGE_BASE)-$(RESTY_IMAGE_TAG)
 KONG_TEST_IMAGE_NAME?=localhost:$(KONG_TEST_CONTAINER_TAG)
 
 # This logic should mirror the kong-build-tools equivalent
-KONG_VERSION?=`echo $(KONG_SOURCE_LOCATION)/kong-*.rockspec | sed 's,.*/,,' | cut -d- -f2`
+KONG_VERSION?=`$(KONG_SOURCE_LOCATION)/distribution/grep-kong-version.sh`
 RESTY_VERSION ?= `grep RESTY_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 KONG_GO_PLUGINSERVER_VERSION ?= `grep KONG_GO_PLUGINSERVER_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_LUAROCKS_VERSION ?= `grep RESTY_LUAROCKS_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`

--- a/release-kong.sh
+++ b/release-kong.sh
@@ -10,7 +10,7 @@ PULP_USERNAME=
 PULP_PASSWORD=
 
 # release finals into prod, others into stage
-if [[ "$KONG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [[ "$KONG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
   PULP_HOST="$PULP_HOST_PROD"
   PULP_USERNAME="$PULP_PROD_USR"
   PULP_PASSWORD="$PULP_PROD_PSW"


### PR DESCRIPTION
We made the decision to support 4 digits in Kong EE (`3.0.0.0`) until
we finish the Unified Data Plane work. I have tested these changes
locally.

Codependent with https://github.com/Kong/kong-ee/pull/3431

Signed-off-by: Tyler Ball <tyler.ball@konghq.com>