### PR TITLE
fix(docker): consistently label all our docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,3 +19,4 @@ jobs:
       uses: ahmadnassri/action-semantic-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+---
+name: BRelease
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches:
+    - master
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Release
+      id: release
+      uses: ahmadnassri/action-semantic-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -13,10 +13,7 @@
         { "type": "fix",      "release": "patch" },
         { "type": "perf",     "release": "patch" },
         { "type": "refactor", "release": "patch" }
-      ],
-      "parserOpts": {
-        "headerPattern": '^(\w*)(?:\(([\w\$\.\-\* ]*)\))? (.*)$'
-      }
+      ]
     }],
     ["@semantic-release/release-notes-generator", {
       "preset": "conventionalcommits",
@@ -33,13 +30,8 @@
           { "type": "style",    "section": "Code Style",  "hidden": false },
           { "type": "test",     "section": "Tests",       "hidden": false }
         ]
-      },
-      "parserOpts": {
-        "headerPattern": '^(\w*)(?:\(([\w\$\.\-\* ]*)\))? (.*)$'
       }
     }],
-    ["@semantic-release/github", {
-      "failComment": false,
-    }]
+    "@semantic-release/github"
   ]
 }

--- a/.releaserc
+++ b/.releaserc
@@ -13,7 +13,7 @@
         { "type": "fix",      "release": "patch" },
         { "type": "perf",     "release": "patch" },
         { "type": "refactor", "release": "patch" }
-      ]
+      ],
       "parserOpts": {
         "headerPattern": '^(\w*)(?:\(([\w\$\.\-\* ]*)\))? (.*)$'
       }
@@ -33,7 +33,7 @@
           { "type": "style",    "section": "Code Style",  "hidden": false },
           { "type": "test",     "section": "Tests",       "hidden": false }
         ]
-      }
+      },
       "parserOpts": {
         "headerPattern": '^(\w*)(?:\(([\w\$\.\-\* ]*)\))? (.*)$'
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,23 +171,5 @@ pipeline {
                 }
             }
         }
-        stage('Release') {
-            agent {
-                node {
-                    label 'bionic'
-                }
-            }
-            when {
-                branch 'master'
-            }
-            environment {
-                GITHUB_TOKEN = credentials('github_bot_access_token')
-            }
-            steps {
-                sh 'curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash'
-                sh '. ~/.nvm/nvm.sh && nvm install lts/*'
-                sh '. ~/.nvm/nvm.sh && npx semantic-release@beta'
-            }
-        }
     }
 }

--- a/release-kong.sh
+++ b/release-kong.sh
@@ -64,9 +64,7 @@ function push_docker_images() {
     "$DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION"
 
   echo "FROM $DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION" | docker build \
-    --label org.opencontainers.image.version="$KONG_VERSION" \
-    --label org.opencontainers.image.created="$DOCKER_LABEL_CREATED" \
-    --label org.opencontainers.image.revision="$DOCKER_LABEL_REVISION" \
+    ${DOCKER_LABELS} \
     -t "$DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION" -
   docker push "$DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION"
 

--- a/test/build_container.sh
+++ b/test/build_container.sh
@@ -37,8 +37,9 @@ pushd ./docker-kong
   
   DOCKER_BUILD_ARGS+=(--no-cache)
   DOCKER_BUILD_ARGS+=(--build-arg ASSET=local .)
-
+  
   docker build --progress=${DOCKER_BUILD_PROGRESS:-auto} -t $KONG_TEST_IMAGE_NAME -f Dockerfile.$PACKAGE_TYPE \
+    ${DOCKER_LABELS} \
     "${DOCKER_BUILD_ARGS[@]}"
 
   docker run -t $KONG_TEST_IMAGE_NAME kong version


### PR DESCRIPTION
kong-ee migrated from `make release` to `make package-kong && make build-test-container`. This led to breaking gojira because the resulting image lacked some labels.

This PR applies the label to `build-test-container` and makes it consistent across all docker images