### PR TITLE
fix(docker): consistent docker image labels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 ---
-name: Release
+name: BRelease
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
@@ -19,3 +19,4 @@ jobs:
       uses: ahmadnassri/action-semantic-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,5 @@
 ---
-name: BRelease
+name: Release
 
 on:  # yamllint disable-line rule:truthy
   pull_request:
@@ -19,4 +19,3 @@ jobs:
       uses: ahmadnassri/action-semantic-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.releaserc
+++ b/.releaserc
@@ -12,7 +12,8 @@
         { "type": "feat",     "release": "minor" },
         { "type": "fix",      "release": "patch" },
         { "type": "perf",     "release": "patch" },
-        { "type": "refactor", "release": "patch" }
+        { "type": "refactor", "release": "patch" },
+        { "type": "chore", "release": "patch" }
       ]
     }],
     ["@semantic-release/release-notes-generator", {

--- a/.releaserc
+++ b/.releaserc
@@ -12,8 +12,7 @@
         { "type": "feat",     "release": "minor" },
         { "type": "fix",      "release": "patch" },
         { "type": "perf",     "release": "patch" },
-        { "type": "refactor", "release": "patch" },
-        { "type": "chore", "release": "patch" }
+        { "type": "refactor", "release": "patch" }
       ]
     }],
     ["@semantic-release/release-notes-generator", {

--- a/release-kong.sh
+++ b/release-kong.sh
@@ -64,9 +64,7 @@ function push_docker_images() {
     "$DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION"
 
   echo "FROM $DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION" | docker build \
-    --label org.opencontainers.image.version="$KONG_VERSION" \
-    --label org.opencontainers.image.created="$DOCKER_LABEL_CREATED" \
-    --label org.opencontainers.image.revision="$DOCKER_LABEL_REVISION" \
+    ${DOCKER_LABELS} \
     -t "$DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION" -
   docker push "$DOCKER_REPOSITORY:$ARCHITECTURE-$KONG_VERSION"
 

--- a/test/build_container.sh
+++ b/test/build_container.sh
@@ -49,6 +49,7 @@ pushd ./docker-kong
   DOCKER_BUILD_ARGS+=(--build-arg ASSET=local .)
 
   docker build --progress=${DOCKER_BUILD_PROGRESS:-auto} -t $KONG_TEST_IMAGE_NAME -f Dockerfile.$PACKAGE_TYPE \
+    ${DOCKER_LABELS} \
     "${DOCKER_BUILD_ARGS[@]}"
 
   docker run -t $KONG_TEST_IMAGE_NAME kong version


### PR DESCRIPTION
kong-ee migrated from `make release` to `make package-kong && make build-test-container`. This led to breaking gojira because the resulting image lacked some labels.

This PR applies the label to build-test-container and makes it consistent across all docker images

Sample failure: https://github.com/Kong/kong-ee/runs/7288776241?check_suite_focus=true
![image](https://user-images.githubusercontent.com/697188/178351871-7ab7a8f9-605c-43a6-87ae-512ccd7c79ff.png)
