### PR TITLE
fix(kong-ngx-build): respect CARGO_HOME when building

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -781,7 +781,7 @@ main() {
       if [ $ATC_ROUTER != 0 ]; then
         pushd $DOWNLOAD_CACHE/atc-router
           warn "installing dynamic library and Lua files for atc-router..."
-          source "$HOME/.cargo/env"
+          source "${CARGO_HOME:-$HOME/.cargo}"/env
           make install LUA_LIB_DIR=$OPENRESTY_INSTALL/lualib
         popd
       fi


### PR DESCRIPTION
This updates kbt to respect the `CARGO_HOME` env var if it's defined. See the [cargo docs](https://doc.rust-lang.org/cargo/reference/environment-variables.html?highlight=CARGO_HOME#environment-variables-cargo-reads)  for more info on this variable.