### PR TITLE
fix(ci): skip setup on Mac OS

### DIFF
--- a/.ci/setup_ci.sh
+++ b/.ci/setup_ci.sh
@@ -8,6 +8,10 @@ if [ "$RESTY_IMAGE_TAG" != "bionic" ] && [ "$RESTY_IMAGE_TAG" != "18.04" ] && [ 
     exit 0
 fi
 
+if uname -a | grep -qs -i darwin; then
+    exit 0
+fi
+
 sudo apt-get install -y \
     qemu \
     binfmt-support \


### PR DESCRIPTION
So as to avoid `sudo apt-get install -y qemu binfmt-support qemu-user-static` on MacOS,