### PR TITLE
fix(releaserc): Explicitly Define repositoryUrl

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,7 @@
 {
   "branches": ["+([0-9])?(.{+([0-9]),x}).x", "master", "next"],
   "tagFormat": "${version}",
+  "repositoryUrl": "https://github.com/Kong/kong-build-tools.git",
   "plugins": [
     [
       "@semantic-release/commit-analyzer",

--- a/.releaserc
+++ b/.releaserc
@@ -1,38 +1,44 @@
 {
-  "branches": ['+([0-9])?(.{+([0-9]),x}).x', 'master', 'next'],
+  "branches": ["+([0-9])?(.{+([0-9]),x}).x", "master", "next"],
   "tagFormat": "${version}",
   "plugins": [
-    ["@semantic-release/commit-analyzer", {
-      "preset": "conventionalcommits",
-      "releaseRules": [
-        { "breaking": true,   "release": "major" },
-        { "revert": true,     "release": "patch" },
-        { "type": "build",    "release": "patch" },
-        { "type": "docs",     "release": "patch" },
-        { "type": "feat",     "release": "minor" },
-        { "type": "fix",      "release": "patch" },
-        { "type": "perf",     "release": "patch" },
-        { "type": "refactor", "release": "patch" },
-        { "type": "chore", "release": "patch" }
-      ]
-    }],
-    ["@semantic-release/release-notes-generator", {
-      "preset": "conventionalcommits",
-      "presetConfig": {
-        "types": [
-          { "type": "build",    "section": "Build",       "hidden": false },
-          { "type": "chore",    "section": "Chores",      "hidden": false },
-          { "type": "ci",       "section": "CI/CD",       "hidden": false },
-          { "type": "docs",     "section": "Docs",        "hidden": false },
-          { "type": "feat",     "section": "Features",    "hidden": false },
-          { "type": "fix",      "section": "Bug Fixes",   "hidden": false },
-          { "type": "perf",     "section": "Performance", "hidden": false },
-          { "type": "refactor", "section": "Refactor",    "hidden": false },
-          { "type": "style",    "section": "Code Style",  "hidden": false },
-          { "type": "test",     "section": "Tests",       "hidden": false }
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "breaking": true, "release": "major" },
+          { "revert": true, "release": "patch" },
+          { "type": "build", "release": "patch" },
+          { "type": "docs", "release": "patch" },
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "chore", "release": "patch" }
         ]
       }
-    }],
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "build", "section": "Build", "hidden": false },
+            { "type": "chore", "section": "Chores", "hidden": false },
+            { "type": "ci", "section": "CI/CD", "hidden": false },
+            { "type": "docs", "section": "Docs", "hidden": false },
+            { "type": "feat", "section": "Features", "hidden": false },
+            { "type": "fix", "section": "Bug Fixes", "hidden": false },
+            { "type": "perf", "section": "Performance", "hidden": false },
+            { "type": "refactor", "section": "Refactor", "hidden": false },
+            { "type": "style", "section": "Code Style", "hidden": false },
+            { "type": "test", "section": "Tests", "hidden": false }
+          ]
+        }
+      }
+    ],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
No idea why the semantic release action started needing this.

~ https://github.com/Kong/kong-build-tools/runs/8280394112?check_suite_focus=true

```
[11:56:06 PM] [semantic-release] › ℹ  Running semantic-release version 19.0.5
[11:56:07 PM] [semantic-release] › ✔  Loaded plugin "verifyConditions" from "@semantic-release/github"
[11:56:07 PM] [semantic-release] › ✔  Loaded plugin "analyzeCommits" from "@semantic-release/commit-analyzer"
[11:56:07 PM] [semantic-release] › ✔  Loaded plugin "generateNotes" from "@semantic-release/release-notes-generator"
[11:56:07 PM] [semantic-release] › ✔  Loaded plugin "publish" from "@semantic-release/github"
[11:56:07 PM] [semantic-release] › ✔  Loaded plugin "addChannel" from "@semantic-release/github"
[11:56:07 PM] [semantic-release] › ✔  Loaded plugin "success" from "@semantic-release/github"
[11:56:07 PM] [semantic-release] › ✔  Loaded plugin "fail" from "@semantic-release/github"
[11:56:07 PM] [semantic-release] › ℹ  Start step "fail" of plugin "@semantic-release/github"
[11:56:07 PM] [semantic-release] [@semantic-release/github] › ℹ  Verify GitHub authentication (https://api.github.com)
[11:56:07 PM] [semantic-release] › ✖  Failed step "fail" of plugin "@semantic-release/github"
[11:56:07 PM] [semantic-release] › ✖  EINVALIDGITHUBURL The git repository URL is not a valid GitHub URL.
The semantic-release repositoryUrl option must a valid GitHub URL with the format <GitHub_or_GHE_URL>/<owner>/<repo>.git.

By default the repositoryUrl option is retrieved from the repository property of your package.json or the git origin url (https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes) of the repository cloned by your CI environment.

[11:56:07 PM] [semantic-release] › ✖  ENOGITREPO Not running from a git repository.
The semantic-release command must be executed from a Git repository.

The current working directory is /github/workspace.

Please verify your CI configuration to make sure the semantic-release command is executed from the root of the cloned repository.

Error: 
    SemanticReleaseError: Not running from a git repository.
        at module.exports (/action/node_modules/semantic-release/lib/get-error.js:6:10)
        at module.exports (/action/node_modules/semantic-release/lib/verify.js:15:17)
        at processTicksAndRejections (node:internal/process/task_queues:[9](https://github.com/Kong/kong-build-tools/runs/8280394112?check_suite_focus=true#step:4:10)6:5)
        at async run (/action/node_modules/semantic-release/index.js:62:3)
        at async module.exports (/action/node_modules/semantic-release/index.js:269:22)
        at async file:///action/index.js:42:[16](https://github.com/Kong/kong-build-tools/runs/8280394112?check_suite_focus=true#step:4:17)
```