### PR TITLE
fix(releaserc): revert to sr 19.0.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,6 @@ jobs:
       uses: actions/checkout@v3
     - name: Release
       id: release
-      uses: ahmadnassri/action-semantic-release@v2
+      uses: ahmadnassri/action-semantic-release@v2.0.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The last known good version of this github action.
Worked as recently as: https://github.com/Kong/kong-build-tools/runs/8117001411?check_suite_focus=true#step:4:7