### PR TITLE
fix(release) Use the correct redhat docker registry format

### DIFF
--- a/test/build_container.sh
+++ b/test/build_container.sh
@@ -36,7 +36,7 @@ pushd ./docker-kong
   then
     major="${RESTY_IMAGE_TAG%%.*}"
 
-    sed -i.bak "s|^FROM .*|FROM registry.access.redhat.com/ubi${major}/ubi:${RESTY_IMAGE_TAG}|" Dockerfile.$PACKAGE_TYPE
+    sed -i.bak "s|^FROM .*|FROM registry.access.redhat.com/ubi${major}|" Dockerfile.$PACKAGE_TYPE
   elif [ "$RESTY_IMAGE_BASE" == "debian" ]; then
     sed -i.bak 's/^FROM .*/FROM '${RESTY_IMAGE_BASE}:${RESTY_IMAGE_TAG}-slim'/' Dockerfile.$PACKAGE_TYPE
   else


### PR DESCRIPTION
Looking at https://catalog.redhat.com/software/containers/search it looks like all the different rhel distributions are at a top level name in the Red Hat registry, IE

registry.access.redhat.com/ubi7
registry.access.redhat.com/ubi8
registry.access.redhat.com/ubi8-minimal

I'm not sure where the 2nd part of the package name came from in the original sed.

Signed-off-by: Tyler Ball <tyler.ball@konghq.com>