### PR TITLE
fix(ngx-build): only try to load env script when cargo is not found

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -851,10 +851,8 @@ main() {
         pushd $DOWNLOAD_CACHE/atc-router
           warn "installing dynamic library and Lua files for atc-router..."
 
-          # this env script adds the cargo bin dir to PATH if missing
-          #
-          # ending with || true allows for when cargo is already on PATH, such as for homebrew-kong
-          source "${CARGO_HOME:-$HOME/.cargo}"/env || true
+          # the env script adds the cargo bin dir to PATH if missing
+          which cargo > /dev/null || source "${CARGO_HOME:-$HOME/.cargo}"/env
           
           # the atc-router makefile also tests for availability of cargo
           make install LUA_LIB_DIR=$OPENRESTY_INSTALL/lualib || atc_router_install_succeed=1


### PR DESCRIPTION
The previous strategy of trying to load the env script unconditionally failed if the script did not exist, despite the '|| true' that was there to avoid that.