### PR TITLE
fix(cache): make sure we nuke the architecture specific image refs: #FTI-4339

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,6 +512,9 @@ cleanup: cleanup-tests cleanup-build
 	-rm -rf output/*
 	-git submodule deinit -f .
 	-docker rmi $(KONG_TEST_IMAGE_NAME)
+	-docker rmi amd64-$(KONG_TEST_CONTAINER_TAG)
+	-docker rmi arm64-$(KONG_TEST_CONTAINER_TAG)
+
 
 update-cache-images:
 ifeq ($(BUILDX),false)


### PR DESCRIPTION
Introduced a bug [here](https://github.com/Kong/kong-build-tools/commit/86e23c347b392d5c01bb8cfd2fdab2ba0e02d8c1#diff-74722fe522ae11801a3294458893ab7ea513c4b899d4ff9089d3a849caf9f50bR8) when we adapted kong-build-tools to use qemu for packaging our multi-architecture images.

adjusted to build `$ARCHITECTURE-$KONG_TEST_CONTAINER_TAG` instead of `$KONG_TEST_CONTAINER_TAG` but missed the cleanup step. Result is running two builds back to back we don't rebuild the subsequent test image