### PR TITLE
fix(security): migrate GITHUB_TOKEN to a buildkit secret file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ kong_license.private
 *.deb
 *.rpm
 openresty-build-tools/build
+github-token

--- a/dockerfiles/Dockerfile.kong
+++ b/dockerfiles/Dockerfile.kong
@@ -1,11 +1,10 @@
+# syntax = docker/dockerfile:1.2
+
 ARG PACKAGE_TYPE
 ARG DOCKER_OPENRESTY_SUFFIX
 ARG DOCKER_REPOSITORY
 
 FROM ${DOCKER_REPOSITORY}:openresty-${PACKAGE_TYPE}-${DOCKER_OPENRESTY_SUFFIX}
-
-ARG GITHUB_TOKEN=
-ENV GITHUB_TOKEN $GITHUB_TOKEN
 
 ARG ENABLE_LJBC=
 ENV ENABLE_LJBC $ENABLE_LJBC
@@ -18,7 +17,7 @@ COPY kong /kong
 
 COPY kong/.requirements kong/distribution/ /distribution/
 WORKDIR /distribution
-RUN if [ -f "/distribution/post-install.sh" ] ; then ./post-install.sh; fi
+RUN --mount=type=secret,id=github-token if [ -f "/distribution/post-install.sh" ] ; then export GITHUB_TOKEN=`cat /run/secrets/github-token` && ./post-install.sh; fi
 
 WORKDIR /kong
 COPY build-kong.sh /build-kong.sh

--- a/dockerfiles/Dockerfile.openresty
+++ b/dockerfiles/Dockerfile.openresty
@@ -1,3 +1,5 @@
+# syntax = docker/dockerfile:1.2
+
 ARG DOCKER_BASE_SUFFIX
 ARG DOCKER_REPOSITORY
 ARG PACKAGE_TYPE
@@ -30,6 +32,7 @@ RUN curl -fsSLo /tmp/yaml-${LIBYAML_VERSION}.tar.gz https://pyyaml.org/download/
 
 COPY kong/.requirements kong/distribution/ /distribution/
 WORKDIR /distribution
+
 RUN if [ -f "/distribution/pre-install.sh" ] ; then ./pre-install.sh; fi
 
 ARG KONG_NGINX_MODULE=master
@@ -83,9 +86,8 @@ RUN sed -i 's/\/tmp\/build//' `grep -l -I -r '\/tmp\/build' /tmp/build/` || true
 COPY kong /kong
 RUN rm -rf /distribution/*
 
-ARG GITHUB_TOKEN
-
 # Initial part of Dockerfile.kong for cache purposes
 COPY kong/.requirements kong/distribution/ /distribution/
 WORKDIR /distribution
-RUN if [ -f "/distribution/post-install.sh" ] ; then ./post-install.sh; fi
+
+RUN --mount=type=secret,id=github-token if [ -f "/distribution/post-install.sh" ] ; then export GITHUB_TOKEN=`cat /run/secrets/github-token` && ./post-install.sh; fi


### PR DESCRIPTION
Instead of relying on a private docker hub repository to gate access to the GITHUB_TOKEN getting baked into the docker images utilise docker buildkit secret file to inject the token