### PR TITLE
chore(yaml): libyaml was moved to the base images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,7 @@ else
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--cache-from $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE) \
 		--cache-from kong/kong-build-tools:openresty-$(PACKAGE_TYPE) \
-		-t $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)-$(DOCKER_OPENRESTY_SUFFIX) . && \
-		-rm github-token \
+		-t $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)-$(DOCKER_OPENRESTY_SUFFIX) . \
 	)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,6 @@ KONG_NGINX_MODULE ?= `grep KONG_NGINX_MODULE $(KONG_SOURCE_LOCATION)/.requiremen
 RESTY_EVENTS ?= `grep RESTY_EVENTS $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_LMDB ?= `grep RESTY_LMDB $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 ATC_ROUTER ?= `grep ATC_ROUTER $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
-LIBYAML_VERSION ?= `grep ^LIBYAML_VERSION $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 RESTY_WEBSOCKET ?= `grep RESTY_WEBSOCKET $(KONG_SOURCE_LOCATION)/.requirements | awk -F"=" '{print $$2}'`
 OPENRESTY_PATCHES ?= 1
 DOCKER_KONG_VERSION = '2.8.1'
@@ -219,7 +218,6 @@ else
 		--build-arg DOCKER_REPOSITORY=$(DOCKER_REPOSITORY) \
 		--build-arg GITHUB_TOKEN=$(GITHUB_TOKEN) \
 		--build-arg DOCKER_BASE_SUFFIX=$(DOCKER_BASE_SUFFIX) \
-		--build-arg LIBYAML_VERSION=$(LIBYAML_VERSION) \
 		--build-arg EDITION=$(EDITION) \
 		--build-arg ENABLE_KONG_LICENSING=$(ENABLE_KONG_LICENSING) \
 		--build-arg KONG_NGINX_MODULE=$(KONG_NGINX_MODULE) \

--- a/dockerfiles/Dockerfile.openresty
+++ b/dockerfiles/Dockerfile.openresty
@@ -2,9 +2,9 @@ ARG DOCKER_BASE_SUFFIX
 ARG DOCKER_REPOSITORY
 ARG PACKAGE_TYPE
 
-FROM kong/kong-build-tools:apk-1.6.1 as APK
-FROM kong/kong-build-tools:deb-1.6.1 as DEB
-FROM kong/kong-build-tools:rpm-1.6.1 as RPM
+FROM kong/kong-build-tools:apk-1.6.3 as APK
+FROM kong/kong-build-tools:deb-1.6.3 as DEB
+FROM kong/kong-build-tools:rpm-1.6.3 as RPM
 
 FROM $PACKAGE_TYPE
 
@@ -12,21 +12,6 @@ ARG EDITION="community"
 ENV EDITION $EDITION
 ARG ENABLE_KONG_LICENSING="true"
 ENV ENABLE_KONG_LICENSING $ENABLE_KONG_LICENSING
-
-ARG LIBYAML_VERSION=0.2.5
-ENV LIBYAML_VERSION $LIBYAML_VERSION
-RUN curl -fsSLo /tmp/yaml-${LIBYAML_VERSION}.tar.gz https://pyyaml.org/download/libyaml/yaml-${LIBYAML_VERSION}.tar.gz \
-    && cd /tmp \
-    && tar xzf yaml-${LIBYAML_VERSION}.tar.gz \
-    && ln -s /tmp/yaml-${LIBYAML_VERSION} /tmp/yaml \
-    && cd /tmp/yaml \
-    && ./configure \
-      --libdir=/tmp/build/usr/local/kong/lib \
-      --includedir=/tmp/yaml-${LIBYAML_VERSION} \
-    && make install \
-    && ./configure --libdir=/usr/local/kong/lib \
-    && make install \
-    && rm -rf /tmp/yaml-${LIBYAML_VERSION}
 
 COPY kong/.requirements kong/distribution/ /distribution/
 WORKDIR /distribution

--- a/dockerfiles/Dockerfile.openresty
+++ b/dockerfiles/Dockerfile.openresty
@@ -4,9 +4,9 @@ ARG DOCKER_BASE_SUFFIX
 ARG DOCKER_REPOSITORY
 ARG PACKAGE_TYPE
 
-FROM kong/kong-build-tools:apk-1.6.3 as APK
-FROM kong/kong-build-tools:deb-1.6.3 as DEB
-FROM kong/kong-build-tools:rpm-1.6.3 as RPM
+FROM kong/kong-build-tools:apk-1.6.4 as APK
+FROM kong/kong-build-tools:deb-1.6.4 as DEB
+FROM kong/kong-build-tools:rpm-1.6.4 as RPM
 
 FROM $PACKAGE_TYPE
 


### PR DESCRIPTION
libyaml has been moved to the [base image](https://github.com/Kong/kong-build-tools-base-images/pull/61)