### PR TITLE
fix(make): account for FROM .. AS dockerfile.or

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ else
 	$(CACHE_COMMAND) $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)-$(DOCKER_OPENRESTY_SUFFIX) || \
 	( \
 		echo $$GITHUB_TOKEN > github-token; \
-		eval "docker pull --quiet $$(sed -ne 's/FROM //p' dockerfiles/Dockerfile.openresty)"; \
+		docker pull --quiet $$(sed -ne 's;FROM \(.*$(PACKAGE_TYPE).*\) as.*;\1;p' dockerfiles/Dockerfile.openresty); \
 		$(DOCKER_COMMAND) -f dockerfiles/Dockerfile.openresty \
 		--secret id=github-token,src=github-token \
 		--build-arg RESTY_VERSION=$(RESTY_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ build-openresty: setup-kong-source
 ifeq ($(RESTY_IMAGE_BASE),src)
 	@echo "nothing to be done"
 else
+	-rm github-token
 	$(CACHE_COMMAND) $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)-$(DOCKER_OPENRESTY_SUFFIX) || \
 	( \
 		echo $$GITHUB_TOKEN > github-token; \
@@ -228,7 +229,10 @@ else
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--cache-from $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE) \
 		--cache-from kong/kong-build-tools:openresty-$(PACKAGE_TYPE) \
-		-t $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)-$(DOCKER_OPENRESTY_SUFFIX) . \
+		-t $(DOCKER_REPOSITORY):openresty-$(PACKAGE_TYPE)-$(DOCKER_OPENRESTY_SUFFIX) . && \
+		( \
+			rm github-token || true \
+		) \
 	)
 endif
 


### PR DESCRIPTION
Should resolve the current silent failure:

```
Pull an image or a repository from a registry
/bin/bash: line 4: kong/kong-build-tools:deb-1.6.1: No such file or directory
/bin/bash: line 5: kong/kong-build-tools:rpm-1.6.1: No such file or directory
/bin/bash: line 6: deb: command not found
```

By making the `docker pull ...` command aware of the recent changes to `Dockerfile.openresty`.