### PR TITLE
feat(openresty): enable ngx_http_sub_module

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -747,6 +747,7 @@ main() {
           "--prefix=$OPENRESTY_PREFIX"
           "--with-pcre-jit"
           "--with-http_ssl_module"
+          "--with-http_sub_module"
           "--with-http_realip_module"
           "--with-http_stub_status_module"
           "--with-http_v2_module"


### PR DESCRIPTION
This pull request adds `--with-http_sub_module` to OpenResty's build options to enable the `ngx_http_sub_module` for https://github.com/Kong/kong-ee/pull/3945.

FTI-976