### PR TITLE
chore(revert)

### DIFF
--- a/dockerfiles/Dockerfile.package
+++ b/dockerfiles/Dockerfile.package
@@ -5,7 +5,7 @@ ARG DOCKER_REPOSITORY
 
 FROM ${DOCKER_REPOSITORY}:kong-${PACKAGE_TYPE}-${DOCKER_KONG_SUFFIX} as KONG
 
-FROM kong/fpm:0.6.0 as FPM
+FROM kong/fpm:0.5.1 as FPM
 
 COPY --from=KONG /tmp/build /tmp/build
 COPY fpm-entrypoint.sh sign-rpm.exp .rpmmacros /

--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -177,7 +177,6 @@ fi
 # kong binaries
 
 if [ "$SSL_PROVIDER" = "openssl" ]; then
-  docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /usr/local/openresty/bin/resty -e 'require("ssl")'
   docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "/usr/local/kong/bin/openssl version | grep -q ${RESTY_OPENSSL_VERSION}"
 fi
 


### PR DESCRIPTION
I think both of these PR's merged prematurely as they were both failing and are now failing on master.

- The kong/fpm failure is unexpected and will need to investigate why rpm signing is failing
- The openssl is linked / loadable has been failing on Kong alpine and gateway engineers need to resolve this