### PR TITLE
chore(make): include pre-make ENVs in debug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ actual-package-kong: cleanup setup-build
 ifeq ($(DEBUG),1)
 	exit 1
 endif
-	make build-kong
+	$(MAKE) build-kong
 	@$(DOCKER_COMMAND) -f dockerfiles/Dockerfile.package \
 	--build-arg RESTY_IMAGE_BASE=$(RESTY_IMAGE_BASE) \
 	--build-arg RESTY_IMAGE_TAG=$(RESTY_IMAGE_TAG) \
@@ -359,7 +359,7 @@ setup-kong-source:
 test-kong: kong-test-container
 	docker-compose up -d
 	bash -c 'healthy=$$(docker-compose ps | grep healthy | wc -l); while [[ "$$(( $$healthy ))" != "3" ]]; do docker-compose ps && sleep 5; done'
-	docker exec kong /kong/.ci/run_tests.sh && make update-cache-images
+	docker exec kong /kong/.ci/run_tests.sh && $(MAKE) update-cache-images
 
 release-kong-docker-images: test
 ifeq ($(BUILDX),false)
@@ -424,7 +424,7 @@ ifeq ($(BUILDX),true)
 	./release-kong.sh
 endif
 ifeq ($(RELEASE_DOCKER),true)
-	make release-kong-docker-images
+	$(MAKE) release-kong-docker-images
 endif
 
 test: build-test-container
@@ -458,7 +458,7 @@ ifneq ($(RESTY_IMAGE_BASE),src)
 	TEST_SHA=$(TEST_SHA) \
 	UPDATE_CACHE_COMMAND="$(UPDATE_CACHE_COMMAND)" \
 	VERBOSE=$(VERBOSE) \
-	./test/run_tests.sh && make update-cache-images
+	./test/run_tests.sh && $(MAKE) update-cache-images
 endif
 
 develop-tests:

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,15 @@ export SHELL:=/bin/bash
 # -pn cause make to print it's "database" of variables without executing any
 # targets (respecitvely)
 ifeq ($(strip $(EARLY)),)
-VARS_OLD := $(filter-out \
-	$(shell \
-		$(MAKE) EARLY=true -pn Makefile \
-			| grep -A1 -E "^# (makefile|environment|default)" \
-			| grep -vE '^(#|\-\-)' \
-			| cut -d' ' -f1; \
-	), \
-	$(.VARIABLES))
+MAKEFILE_VARS := $(shell $(MAKE) EARLY=true -pn Makefile \
+	| grep -vE 'starting make|VARS_OLD|.VARIABLES' \
+	| grep -A1 -E '\x23 makefile|\x23 environment|\x23 default' \
+	| grep -vE '^\x23|^\-\-' \
+	| cut -d ' ' -f1 \
+	; )
 endif
+
+VARS_OLD = $(filter-out $(MAKEFILE_VARS),$(.VARIABLES))
 
 VERBOSE?=false
 RESTY_IMAGE_BASE?=ubuntu

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,7 @@ debug:
 			echo  $(v) = "$($(v))" ;  \
 		) | uniq ; \
 	)
+	$(MAKE) -v
 
 setup-ci: setup-build
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,26 @@
 $(info starting make in kong-build-tools)
 
-VARS_OLD := $(.VARIABLES)
-
 .PHONY: test build-kong
 .DEFAULT_GOAL := package-kong
 
 export SHELL:=/bin/bash
+# .SHELLFLAGS+=-x
+
+# collect the list of environment variables to care about for the debug target
+# from this Makefile itself
+#
+# -pn cause make to print it's "database" of variables without executing any
+# targets (respecitvely)
+ifeq ($(strip $(EARLY)),)
+VARS_OLD := $(filter-out \
+	$(shell \
+		$(MAKE) EARLY=true -pn Makefile \
+			| grep -A1 -E "^# (makefile|environment|default)" \
+			| grep -vE '^(#|\-\-)' \
+			| cut -d' ' -f1; \
+	), \
+	$(.VARIABLES))
+endif
 
 VERBOSE?=false
 RESTY_IMAGE_BASE?=ubuntu
@@ -155,8 +170,8 @@ debug:
 	@$(foreach v, \
 		$(sort $(filter-out $(VARS_OLD) VARS_OLD,$(.VARIABLES))), \
 		( \
-			echo '$(v) = $($(v))' ; echo \
-			      $(v) = $($(v)) ;  \
+			echo '$(v) = $($(v))'  ; \
+			echo  $(v) = "$($(v))" ;  \
 		) | uniq ; \
 	)
 


### PR DESCRIPTION
Previously, the `debug` make target didn't display ENVs that existed in the environment, or make default variables, before make ran because `VARS_OLD := $(.VARIABLES)` naively includes all existing ENVs and default make variables.

Now, the debug make target will inspect this makefile itself using `make -pn ...` to get a more complete list of variables (make + environment).

This PR also fixes a minor bug where an ENV that had a semicolon in it wouldn't be displayed properly:
```
$ export COLORFGBG='15;0'
$ make debug
...
/bin/bash: 0: command not found
COLORFGBG = 15;0
COLORFGBG = 15
...
```