### PR TITLE
fix(patches) apply luajit patch cleanly

### DIFF
--- a/openresty-patches/patches/1.21.4.1/LuaJIT-2.1-20220411_02.patch
+++ b/openresty-patches/patches/1.21.4.1/LuaJIT-2.1-20220411_02.patch
@@ -12,7 +12,7 @@ diff --git a/LuaJIT-2.1-20220411/src/lj_record.c b/LuaJIT-2.1-20220411/src/lj_re
 index 5d02d24a1..bfd412365 100644
 --- a/LuaJIT-2.1-20220411/src/lj_record.c
 +++ b/LuaJIT-2.1-20220411/src/lj_record.c
-@@ -2572,7 +2572,8 @@ void lj_record_ins(jit_State *J)
+@@ -2566,7 +2566,8 @@ void lj_record_ins(jit_State *J)
      break;
    case BC_JLOOP:
      rec_loop_jit(J, rc, rec_loop(J, ra,


### PR DESCRIPTION
### Summary

There is a wrong offset in patch, so it complains about it with a notice:

```
patching file LuaJIT-2.1-20220411/src/lj_record.c
patch unexpectedly ends in middle of line
Hunk #1 succeeded at 2566 with fuzz 1 (offset -6 lines).
```

This commit fixes the offset.