### PR TITLE
feat(build) include boringssl headers in final distro

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -727,7 +727,7 @@ main() {
         popd #.openssl
 
         cp -vp build/crypto/libcrypto.* build/ssl/libssl.* $OPENSSL_DESTDIR$OPENSSL_PREFIX/lib
-
+        cp -rvp include/openssl $OPENSSL_DESTDIR$OPENSSL_PREFIX/include/
       popd # $OPENRESTY_DOWNLOAD
       succ "BoringSSL $BORINGSSL_VER has been built successfully!"
 

--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -159,6 +159,7 @@ docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "grep 
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ls -l /etc/kong/kong.conf.default"
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ls -l /etc/kong/kong*.logrotate"
 docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ls -l /usr/local/kong/include/google/protobuf/*.proto"
+docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ls -l /usr/local/kong/include/openssl/*.h"
 
 if [ -e ${KONG_SOURCE_LOCATION}/kong/include/kong/pluginsocket.proto ]; then
   docker run ${USE_TTY} --user=root --rm ${KONG_TEST_IMAGE_NAME} /bin/sh -c "ls -l /usr/local/kong/include/kong/pluginsocket.proto"


### PR DESCRIPTION
Ensure boringssl headers are included in packages - which is already done for openssl and required by LuaSec.

FT-3384