### PR TITLE
fix(patches): dyn upstream keepalive

### DIFF
--- a/openresty-patches/patches/1.21.4.1/lua-resty-core-0.1.23_02-dyn_upstream_keepalive.patch
+++ b/openresty-patches/patches/1.21.4.1/lua-resty-core-0.1.23_02-dyn_upstream_keepalive.patch
@@ -1,62 +1,42 @@
-From 37feb95041f183ae4fbafeebc47dc104995e6f27 Mon Sep 17 00:00:00 2001
-From: Thibault Charbonnier <thibaultcha@me.com>
-Date: Tue, 17 Sep 2019 11:44:33 -0700
-Subject: [PATCH] feature: implemented the 'balancer.enable_keepalive()' API.
-
----
- lua-resty-core-0.1.23/lib/ngx/balancer.lua | 165 +++++++++++++++++++++++++++++++++++++++----
- 1 file changed, 151 insertions(+), 14 deletions(-)
-
-diff --git a/lua-resty-core-0.1.23/lib/ngx/balancer.lua b/lua-resty-core-0.1.23/lib/ngx/balancer.lua
-index d584639..614312f 100644
---- a/lua-resty-core-0.1.23/lib/ngx/balancer.lua
-+++ b/lua-resty-core-0.1.23/lib/ngx/balancer.lua
-@@ -3,6 +3,7 @@
-
- local base = require "resty.core.base"
- base.allows_subsystem('http', 'stream')
-+require "resty.core.hash"
-
-
- local ffi = require "ffi"
-@@ -17,8 +18,10 @@ local error = error
- local type = type
- local tonumber = tonumber
+diff -ruN a/lua-resty-core-0.1.23/lib/ngx/balancer.lua b/lua-resty-core-0.1.23/lib/ngx/balancer.lua
+--- a/lua-resty-core-0.1.23/lib/ngx/balancer.lua	2022-12-02 10:58:50.078203826 +0800
++++ b/lua-resty-core-0.1.23/lib/ngx/balancer.lua	2022-12-02 11:14:13.936414523 +0800
+@@ -19,6 +19,7 @@
  local max = math.max
-+local ngx_crc32_long = ngx.crc32_long
  local subsystem = ngx.config.subsystem
  local ngx_lua_ffi_balancer_set_current_peer
 +local ngx_lua_ffi_balancer_enable_keepalive
  local ngx_lua_ffi_balancer_set_more_tries
  local ngx_lua_ffi_balancer_get_last_failure
  local ngx_lua_ffi_balancer_set_timeouts -- used by both stream and http
-@@ -27,7 +30,11 @@ local ngx_lua_ffi_balancer_set_timeouts -- used by both stream and http
+@@ -27,7 +28,12 @@
  if subsystem == 'http' then
      ffi.cdef[[
      int ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
 -        const unsigned char *addr, size_t addr_len, int port, char **err);
 +        const unsigned char *addr, size_t addr_len, int port,
-+        unsigned int cpool_crc32, unsigned int cpool_size, char **err);
++        const unsigned char *cpool_name, size_t cpool_name_len,
++        unsigned int cpool_size, char **err);
 +
 +    int ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
 +        unsigned long timeout, unsigned int max_requests, char **err);
-
+ 
      int ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
          int count, char **err);
-@@ -46,6 +53,9 @@ if subsystem == 'http' then
+@@ -46,6 +52,9 @@
      ngx_lua_ffi_balancer_set_current_peer =
          C.ngx_http_lua_ffi_balancer_set_current_peer
-
+ 
 +    ngx_lua_ffi_balancer_enable_keepalive =
 +        C.ngx_http_lua_ffi_balancer_enable_keepalive
 +
      ngx_lua_ffi_balancer_set_more_tries =
          C.ngx_http_lua_ffi_balancer_set_more_tries
-
-@@ -96,6 +106,11 @@ else
+ 
+@@ -96,6 +105,11 @@
  end
-
-
+ 
+ 
 +local DEFAULT_KEEPALIVE_POOL_SIZE = 30
 +local DEFAULT_KEEPALIVE_IDLE_TIMEOUT = 60000
 +local DEFAULT_KEEPALIVE_MAX_REQUESTS = 100
@@ -65,10 +45,10 @@ index d584639..614312f 100644
  local peer_state_names = {
      [1] = "keepalive",
      [2] = "next",
-@@ -106,25 +121,147 @@ local peer_state_names = {
+@@ -106,25 +120,144 @@
  local _M = { version = base.version }
-
-
+ 
+ 
 -function _M.set_current_peer(addr, port)
 -    local r = get_request()
 -    if not r then
@@ -80,7 +60,7 @@ index d584639..614312f 100644
 +            error("no request found")
 +        end
 +
-+        local pool_crc32
++        local pool
 +        local pool_size
 +
 +        if opts then
@@ -89,16 +69,17 @@ index d584639..614312f 100644
 +                      "(table expected, got " .. type(opts) .. ")", 2)
 +            end
 +
-+            local pool = opts.pool
++            pool = opts.pool
 +            pool_size = opts.pool_size
 +
-+            if pool then
++            if not pool then
++                pool = ""
++
++            else
 +                if type(pool) ~= "string" then
 +                    error("bad option 'pool' to 'set_current_peer' " ..
 +                          "(string expected, got " .. type(pool) .. ")", 2)
 +                end
-+
-+                pool_crc32 = ngx_crc32_long(pool)
 +            end
 +
 +            if pool_size then
@@ -120,16 +101,12 @@ index d584639..614312f 100644
 +            port = tonumber(port)
 +        end
 +
-+        if not pool_crc32 then
-+            pool_crc32 = 0
-+        end
-+
 +        if not pool_size then
 +            pool_size = DEFAULT_KEEPALIVE_POOL_SIZE
 +        end
 +
 +        local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr, port,
-+                                                         pool_crc32, pool_size,
++                                                         pool, #pool, pool_size,
 +                                                         errmsg)
 +        if rc == FFI_OK then
 +            return true
@@ -137,7 +114,7 @@ index d584639..614312f 100644
 +
 +        return nil, ffi_str(errmsg[0])
      end
-
+ 
 -    if not port then
 -        port = 0
 -    elseif type(port) ~= "number" then
@@ -170,11 +147,7 @@ index d584639..614312f 100644
 +        return nil, ffi_str(errmsg[0])
      end
 +end
-
--    local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr,
--                                                     port, errmsg)
--    if rc == FFI_OK then
--        return true
++
 +
 +if subsystem == "http" then
 +    function _M.enable_keepalive(idle_timeout, max_requests)
@@ -189,7 +162,11 @@ index d584639..614312f 100644
 +        elseif type(idle_timeout) ~= "number" then
 +            error("bad argument #1 to 'enable_keepalive' " ..
 +                  "(number expected, got " .. type(idle_timeout) .. ")", 2)
-+
+ 
+-    local rc = ngx_lua_ffi_balancer_set_current_peer(r, addr, #addr,
+-                                                     port, errmsg)
+-    if rc == FFI_OK then
+-        return true
 +        elseif idle_timeout < 0 then
 +            error("bad argument #1 to 'enable_keepalive' (expected >= 0)", 2)
 +
@@ -216,7 +193,7 @@ index d584639..614312f 100644
 +
 +        return nil, ffi_str(errmsg[0])
      end
-
+ 
 -    return nil, ffi_str(errmsg[0])
 +else
 +    function _M.enable_keepalive()
@@ -224,7 +201,5 @@ index d584639..614312f 100644
 +              " subsystem", 2)
 +    end
  end
-
-
---
-2.25.2
+ 
+ 

--- a/openresty-patches/patches/1.21.4.1/lua-resty-core-0.1.23_02-dyn_upstream_keepalive.patch
+++ b/openresty-patches/patches/1.21.4.1/lua-resty-core-0.1.23_02-dyn_upstream_keepalive.patch
@@ -1,6 +1,6 @@
 diff -ruN a/lua-resty-core-0.1.23/lib/ngx/balancer.lua b/lua-resty-core-0.1.23/lib/ngx/balancer.lua
 --- a/lua-resty-core-0.1.23/lib/ngx/balancer.lua	2022-12-02 10:58:50.078203826 +0800
-+++ b/lua-resty-core-0.1.23/lib/ngx/balancer.lua	2022-12-02 11:14:13.936414523 +0800
++++ b/lua-resty-core-0.1.23/lib/ngx/balancer.lua	2022-12-03 11:50:57.271540206 +0800
 @@ -19,6 +19,7 @@
  local max = math.max
  local subsystem = ngx.config.subsystem
@@ -45,7 +45,7 @@ diff -ruN a/lua-resty-core-0.1.23/lib/ngx/balancer.lua b/lua-resty-core-0.1.23/l
  local peer_state_names = {
      [1] = "keepalive",
      [2] = "next",
-@@ -106,25 +120,144 @@
+@@ -106,25 +120,145 @@
  local _M = { version = base.version }
  
  
@@ -72,10 +72,7 @@ diff -ruN a/lua-resty-core-0.1.23/lib/ngx/balancer.lua b/lua-resty-core-0.1.23/l
 +            pool = opts.pool
 +            pool_size = opts.pool_size
 +
-+            if not pool then
-+                pool = ""
-+
-+            else
++            if pool then
 +                if type(pool) ~= "string" then
 +                    error("bad option 'pool' to 'set_current_peer' " ..
 +                          "(string expected, got " .. type(pool) .. ")", 2)
@@ -99,6 +96,10 @@ diff -ruN a/lua-resty-core-0.1.23/lib/ngx/balancer.lua b/lua-resty-core-0.1.23/l
 +
 +        elseif type(port) ~= "number" then
 +            port = tonumber(port)
++        end
++
++        if not pool then
++            pool = ""
 +        end
 +
 +        if not pool_size then

--- a/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -1,6 +1,6 @@
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 10:58:50.054203731 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 12:02:15.121733885 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 14:09:20.504976137 +0800
 @@ -16,46 +16,107 @@
  #include "ngx_http_lua_directive.h"
  
@@ -44,7 +44,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 -    ngx_uint_t                          more_tries;
 -    ngx_uint_t                          total_tries;
 +    //uint32_t                                cpool_crc32;
-+    ngx_str_t                              *cpool_name;
++    ngx_str_t                               cpool_name;
  
 -    struct sockaddr                    *sockaddr;
 -    socklen_t                           socklen;
@@ -423,12 +423,12 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
 -        dd("tries: %d", (int) r->upstream->peer.tries);
 +        if (ngx_http_lua_balancer_keepalive_is_enabled(bp)) {
-+            ngx_http_lua_balancer_get_keepalive_pool(L, bp->cpool_name,
++            ngx_http_lua_balancer_get_keepalive_pool(L, &bp->cpool_name,
 +                                                     &bp->cpool);
 +
 +            if (bp->cpool == NULL
 +                && ngx_http_lua_balancer_create_keepalive_pool(L, pc->log,
-+                                                               bp->cpool_name,
++                                                               &bp->cpool_name,
 +                                                               bp->cpool_size,
 +                                                               &bp->cpool)
 +                   != NGX_OK)
@@ -984,23 +984,24 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (url.addrs && url.addrs[0].sockaddr) {
          bp->sockaddr = url.addrs[0].sockaddr;
          bp->socklen = url.addrs[0].socklen;
-@@ -536,6 +1030,78 @@
+@@ -536,6 +1030,79 @@
          return NGX_ERROR;
      }
  
 +    //bp->cpool_crc32 = (uint32_t) cpool_crc32;
 +
 +    if (cpool_name_len == 0) {
-+        bp->cpool_name = bp->host;
++        bp->cpool_name = *bp->host;
 +
 +    } else {
-+        bp->cpool_name = ngx_palloc(r->pool, cpool_name_len);
-+        if (bp->cpool_name == NULL) {
++        bp->cpool_name.data = ngx_palloc(r->pool, cpool_name_len);
++        if (bp->cpool_name.data == NULL) {
 +            *err = "no memory";
 +            return NGX_ERROR;
 +        }
 +
-+        ngx_memcpy(bp->cpool_name, cpool_name, cpool_name_len);
++        ngx_memcpy(bp->cpool_name.data, cpool_name, cpool_name_len);
++        bp->cpool_name.len = cpool_name_len;
 +    }
 +
 +
@@ -1052,8 +1053,8 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    //    bp->cpool_crc32 = ngx_crc32_long(bp->host->data, bp->host->len);
 +    //}
 +
-+    if (!bp->cpool_name) {
-+        bp->cpool_name = bp->host;
++    if (!bp->cpool_name.data) {
++        bp->cpool_name = *bp->host;
 +    }
 +
 +    bp->keepalive_timeout = (ngx_msec_t) timeout;
@@ -1063,7 +1064,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      return NGX_OK;
  }
  
-@@ -545,14 +1111,13 @@
+@@ -545,14 +1112,13 @@
      long connect_timeout, long send_timeout, long read_timeout,
      char **err)
  {
@@ -1081,7 +1082,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -577,15 +1142,9 @@
+@@ -577,15 +1143,9 @@
          return NGX_ERROR;
      }
  
@@ -1099,7 +1100,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (!bp->cloned_upstream_conf) {
          /* we clone the upstream conf for the current request so that
           * we do not affect other requests at all. */
-@@ -640,12 +1199,10 @@
+@@ -640,12 +1200,10 @@
      int count, char **err)
  {
  #if (nginx_version >= 1007005)
@@ -1115,7 +1116,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_http_lua_balancer_peer_data_t  *bp;
  
      if (r == NULL) {
-@@ -671,13 +1228,7 @@
+@@ -671,13 +1229,7 @@
          return NGX_ERROR;
      }
  
@@ -1130,7 +1131,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
  #if (nginx_version >= 1007005)
      max_tries = r->upstream->conf->next_upstream_tries;
-@@ -703,12 +1254,10 @@
+@@ -703,12 +1255,10 @@
  ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
      int *status, char **err)
  {
@@ -1146,7 +1147,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -733,13 +1282,7 @@
+@@ -733,13 +1283,7 @@
          return NGX_ERROR;
      }
  
@@ -1191,7 +1192,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_
          u_char                              *src_key;
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_module.c b/ngx_lua-0.10.21/src/ngx_http_lua_module.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 10:58:50.050203715 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 12:02:15.121733885 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 14:09:20.504976137 +0800
 @@ -1117,6 +1117,9 @@
       *      lscf->srv.ssl_session_fetch_src = { 0, NULL };
       *      lscf->srv.ssl_session_fetch_src_key = NULL;

--- a/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -1,28 +1,16 @@
-From 2d12ac3e4045258b7a174b0505d92f63c26d82fc Mon Sep 17 00:00:00 2001
-From: Thibault Charbonnier <thibaultcha@me.com>
-Date: Tue, 17 Sep 2019 11:43:44 -0700
-Subject: [PATCH 1/3] feature: implemented keepalive pooling in
- 'balancer_by_lua*'.
-
----
- src/ngx_http_lua_balancer.c | 738 ++++++++++++++++++++++++++++++------
- src/ngx_http_lua_common.h   |   4 +
- src/ngx_http_lua_module.c   |   3 +
- 3 files changed, 629 insertions(+), 116 deletions(-)
-
-diff --git a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
-index f71a3e00..0d403716 100644
---- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
-@@ -16,46 +16,102 @@
+diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
+--- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 10:58:50.054203731 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 12:02:15.121733885 +0800
+@@ -16,46 +16,107 @@
  #include "ngx_http_lua_directive.h"
-
-
+ 
+ 
 +typedef struct {
 +    ngx_uint_t                               size;
 +    ngx_uint_t                               connections;
 +
-+    uint32_t                                 crc32;
++    //uint32_t                                 crc32;
++    ngx_str_t                                cpool_name;
 +
 +    lua_State                               *lua_vm;
 +
@@ -48,30 +36,31 @@ index f71a3e00..0d403716 100644
 +
 +    ngx_uint_t                              more_tries;
 +    ngx_uint_t                              total_tries;
-
+ 
 -    ngx_http_lua_srv_conf_t            *conf;
 -    ngx_http_request_t                 *request;
 +    int                                     last_peer_state;
-
+ 
 -    ngx_uint_t                          more_tries;
 -    ngx_uint_t                          total_tries;
-+    uint32_t                                cpool_crc32;
-
++    //uint32_t                                cpool_crc32;
++    ngx_str_t                              *cpool_name;
+ 
 -    struct sockaddr                    *sockaddr;
 -    socklen_t                           socklen;
 +    void                                   *data;
-
+ 
 -    ngx_str_t                          *host;
 -    in_port_t                           port;
 +    ngx_event_get_peer_pt                   original_get_peer;
 +    ngx_event_free_peer_pt                  original_free_peer;
-
--    int                                 last_peer_state;
++
 +#if (NGX_HTTP_SSL)
 +    ngx_event_set_peer_session_pt           original_set_session;
 +    ngx_event_save_peer_session_pt          original_save_session;
 +#endif
-+
+ 
+-    int                                 last_peer_state;
 +    ngx_http_request_t                     *request;
 +    ngx_http_lua_srv_conf_t                *conf;
 +    ngx_http_lua_balancer_keepalive_pool_t *cpool;
@@ -82,14 +71,14 @@ index f71a3e00..0d403716 100644
 +    socklen_t                               socklen;
 +
 +    unsigned                                keepalive:1;
-
+ 
  #if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
 -    unsigned                            cloned_upstream_conf;  /* :1 */
 +    unsigned                                cloned_upstream_conf:1;
  #endif
  };
-
-
+ 
+ 
 -#if (NGX_HTTP_SSL)
 -static ngx_int_t ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc,
 -    void *data);
@@ -109,10 +98,12 @@ index f71a3e00..0d403716 100644
  static void ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc,
      void *data, ngx_uint_t state);
 +static ngx_int_t ngx_http_lua_balancer_create_keepalive_pool(lua_State *L,
-+    ngx_log_t *log, uint32_t cpool_crc32, ngx_uint_t cpool_size,
++    //ngx_log_t *log, uint32_t cpool_crc32, ngx_uint_t cpool_size,
++    ngx_log_t *log, ngx_str_t *cpool_name, ngx_uint_t cpool_size,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool);
 +static void ngx_http_lua_balancer_get_keepalive_pool(lua_State *L,
-+    uint32_t cpool_crc32, ngx_http_lua_balancer_keepalive_pool_t **cpool);
++    //uint32_t cpool_crc32, ngx_http_lua_balancer_keepalive_pool_t **cpool);
++    ngx_str_t *cpool_name, ngx_http_lua_balancer_keepalive_pool_t **cpool);
 +static void ngx_http_lua_balancer_free_keepalive_pool(ngx_log_t *log,
 +    ngx_http_lua_balancer_keepalive_pool_t *cpool);
 +static void ngx_http_lua_balancer_close(ngx_connection_t *c);
@@ -133,14 +124,15 @@ index f71a3e00..0d403716 100644
 +    (bp->sockaddr && bp->socklen)
 +
 +
-+static char ngx_http_lua_balancer_keepalive_pools_table_key;
-
-
++static char              ngx_http_lua_balancer_keepalive_pools_table_key;
++static struct sockaddr  *ngx_http_lua_balancer_default_server_sockaddr;
+ 
+ 
  ngx_int_t
-@@ -102,6 +158,61 @@ ngx_http_lua_balancer_handler_inline(ngx_http_request_t *r,
+@@ -102,6 +163,61 @@
  }
-
-
+ 
+ 
 +static ngx_int_t
 +ngx_http_lua_balancer_by_chunk(lua_State *L, ngx_http_request_t *r)
 +{
@@ -199,7 +191,7 @@ index f71a3e00..0d403716 100644
  char *
  ngx_http_lua_balancer_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
      void *conf)
-@@ -125,16 +236,16 @@ char *
+@@ -125,16 +241,18 @@
  ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
      void *conf)
  {
@@ -211,25 +203,50 @@ index f71a3e00..0d403716 100644
 +    u_char                            *cache_key = NULL;
 +    u_char                            *name;
 +    ngx_str_t                         *value;
++    ngx_url_t                          url;
      ngx_http_upstream_srv_conf_t      *uscf;
++    ngx_http_upstream_server_t        *us;
 +    ngx_http_lua_srv_conf_t           *lscf = conf;
-
+ 
      dd("enter");
-
+ 
 -    /*  must specify a content handler */
 +    /* content handler setup */
 +
      if (cmd->post == NULL) {
          return NGX_CONF_ERROR;
      }
-@@ -178,11 +289,19 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
-
+@@ -178,11 +296,42 @@
+ 
      lscf->balancer.src_key = cache_key;
-
+ 
 +    /* balancer setup */
 +
      uscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
-
+ 
++    if (uscf->servers->nelts == 0) {
++        us = ngx_array_push(uscf->servers);
++        if (us == NULL) {
++            return NGX_CONF_ERROR;
++        }
++
++        ngx_memzero(us, sizeof(ngx_http_upstream_server_t));
++        ngx_memzero(&url, sizeof(ngx_url_t));
++
++        ngx_str_set(&url.url, "0.0.0.1");
++        url.default_port = 80;
++
++        if (ngx_parse_url(cf->pool, &url) != NGX_OK) {
++            return NGX_CONF_ERROR;
++        }
++
++        us->name = url.url;
++        us->addrs = url.addrs;
++        us->naddrs = url.naddrs;
++
++        ngx_http_lua_balancer_default_server_sockaddr = us->addrs[0].sockaddr;
++    }
++
      if (uscf->peer.init_upstream) {
          ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
                             "load balancing method redefined");
@@ -240,11 +257,11 @@ index f71a3e00..0d403716 100644
 +        lscf->balancer.original_init_upstream =
 +            ngx_http_upstream_init_round_robin;
      }
-
+ 
      uscf->peer.init_upstream = ngx_http_lua_balancer_init;
-@@ -198,14 +317,18 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
-
-
+@@ -198,14 +347,18 @@
+ 
+ 
  static ngx_int_t
 -ngx_http_lua_balancer_init(ngx_conf_t *cf,
 -    ngx_http_upstream_srv_conf_t *us)
@@ -258,21 +275,21 @@ index f71a3e00..0d403716 100644
 +    if (lscf->balancer.original_init_upstream(cf, us) != NGX_OK) {
          return NGX_ERROR;
      }
-
+ 
 -    /* this callback is called upon individual requests */
 +    lscf->balancer.original_init_peer = us->peer.init;
 +
      us->peer.init = ngx_http_lua_balancer_init_peer;
-
+ 
      return NGX_OK;
-@@ -216,33 +339,38 @@ static ngx_int_t
+@@ -216,33 +369,38 @@
  ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
      ngx_http_upstream_srv_conf_t *us)
  {
 -    ngx_http_lua_srv_conf_t            *bcf;
 +    ngx_http_lua_srv_conf_t            *lscf;
      ngx_http_lua_balancer_peer_data_t  *bp;
-
+ 
 -    bp = ngx_pcalloc(r->pool, sizeof(ngx_http_lua_balancer_peer_data_t));
 -    if (bp == NULL) {
 +    lscf = ngx_http_conf_upstream_srv_conf(us, ngx_http_lua_module);
@@ -280,7 +297,7 @@ index f71a3e00..0d403716 100644
 +    if (lscf->balancer.original_init_peer(r, us) != NGX_OK) {
          return NGX_ERROR;
      }
-
+ 
 -    r->upstream->peer.data = &bp->rrp;
 -
 -    if (ngx_http_upstream_init_round_robin_peer(r, us) != NGX_OK) {
@@ -288,7 +305,7 @@ index f71a3e00..0d403716 100644
 +    if (bp == NULL) {
          return NGX_ERROR;
      }
-
+ 
 +    bp->conf = lscf;
 +    bp->request = r;
 +    bp->data = r->upstream->peer.data;
@@ -298,7 +315,7 @@ index f71a3e00..0d403716 100644
 +    r->upstream->peer.data = bp;
      r->upstream->peer.get = ngx_http_lua_balancer_get_peer;
      r->upstream->peer.free = ngx_http_lua_balancer_free_peer;
-
+ 
  #if (NGX_HTTP_SSL)
 +    bp->original_set_session = r->upstream->peer.set_session;
 +    bp->original_save_session = r->upstream->peer.save_session;
@@ -306,7 +323,7 @@ index f71a3e00..0d403716 100644
      r->upstream->peer.set_session = ngx_http_lua_balancer_set_session;
      r->upstream->peer.save_session = ngx_http_lua_balancer_save_session;
  #endif
-
+ 
 -    bcf = ngx_http_conf_upstream_srv_conf(us, ngx_http_lua_module);
 -
 -    bp->conf = bcf;
@@ -314,8 +331,8 @@ index f71a3e00..0d403716 100644
 -
      return NGX_OK;
  }
-
-@@ -250,25 +378,26 @@ ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
+ 
+@@ -250,25 +408,26 @@
  static ngx_int_t
  ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
  {
@@ -333,54 +350,62 @@ index f71a3e00..0d403716 100644
 +    ngx_http_request_t                     *r;
 +    ngx_http_lua_ctx_t                     *ctx;
 +    ngx_http_lua_srv_conf_t                *lscf;
-+    ngx_http_lua_main_conf_t               *lmcf;
 +    ngx_http_lua_balancer_keepalive_item_t *item;
 +    ngx_http_lua_balancer_peer_data_t      *bp = data;
-
++    void                                   *pdata;
+ 
      ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
 -                   "lua balancer peer, tries: %ui", pc->tries);
 -
 -    lscf = bp->conf;
 +                   "lua balancer: get peer, tries: %ui", pc->tries);
-
+ 
      r = bp->request;
 +    lscf = bp->conf;
-
+ 
      ngx_http_lua_assert(lscf->balancer.handler && r);
-
+ 
      ctx = ngx_http_get_module_ctx(r, ngx_http_lua_module);
 -
      if (ctx == NULL) {
          ctx = ngx_http_lua_create_ctx(r);
          if (ctx == NULL) {
-@@ -286,9 +415,15 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
-
+@@ -286,21 +445,24 @@
+ 
      ctx->context = NGX_HTTP_LUA_CONTEXT_BALANCER;
-
+ 
 +    bp->cpool = NULL;
      bp->sockaddr = NULL;
      bp->socklen = 0;
      bp->more_tries = 0;
-+    bp->cpool_crc32 = 0;
++    //bp->cpool_crc32 = 0;
 +    bp->cpool_size = 0;
 +    bp->keepalive_requests = 0;
 +    bp->keepalive_timeout = 0;
 +    bp->keepalive = 0;
      bp->total_tries++;
-
-     lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
-@@ -300,7 +435,6 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
-     lmcf->balancer_peer_data = bp;
-
-     rc = lscf->balancer.handler(r, lscf, L);
+ 
+-    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 -
+-    /* balancer_by_lua does not support yielding and
+-     * there cannot be any conflicts among concurrent requests,
+-     * thus it is safe to store the peer data in the main conf.
+-     */
+-    lmcf->balancer_peer_data = bp;
++    pdata = r->upstream->peer.data;
++    r->upstream->peer.data = bp;
+ 
+     rc = lscf->balancer.handler(r, lscf, L);
+ 
++    r->upstream->peer.data = pdata;
++
      if (rc == NGX_ERROR) {
          return NGX_ERROR;
      }
-@@ -322,105 +456,414 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
+@@ -322,105 +484,448 @@
          }
      }
-
+ 
 -    if (bp->sockaddr && bp->socklen) {
 +    if (ngx_http_lua_balancer_peer_set(bp)) {
          pc->sockaddr = bp->sockaddr;
@@ -391,19 +416,19 @@ index f71a3e00..0d403716 100644
 -        pc->name = bp->host;
 -
 -        bp->rrp.peers->single = 0;
-
+ 
          if (bp->more_tries) {
              r->upstream->peer.tries += bp->more_tries;
          }
-
+ 
 -        dd("tries: %d", (int) r->upstream->peer.tries);
 +        if (ngx_http_lua_balancer_keepalive_is_enabled(bp)) {
-+            ngx_http_lua_balancer_get_keepalive_pool(L, bp->cpool_crc32,
++            ngx_http_lua_balancer_get_keepalive_pool(L, bp->cpool_name,
 +                                                     &bp->cpool);
 +
 +            if (bp->cpool == NULL
 +                && ngx_http_lua_balancer_create_keepalive_pool(L, pc->log,
-+                                                               bp->cpool_crc32,
++                                                               bp->cpool_name,
 +                                                               bp->cpool_size,
 +                                                               &bp->cpool)
 +                   != NGX_OK)
@@ -451,15 +476,27 @@ index f71a3e00..0d403716 100644
 +                           "lua balancer: keepalive no free connection, "
 +                           "cpool: %p", bp->cpool);
 +        }
-
+ 
          return NGX_OK;
      }
-
+ 
 -    return ngx_http_upstream_get_round_robin_peer(pc, &bp->rrp);
-+    return bp->original_get_peer(pc, bp->data);
++    rc = bp->original_get_peer(pc, bp->data);
++    if (rc == NGX_ERROR) {
++        return rc;
++    }
++
++    if (pc->sockaddr == ngx_http_lua_balancer_default_server_sockaddr) {
++        ngx_log_error(NGX_LOG_ERR, pc->log, 0,
++                      "lua balancer: no peer set");
++
++        return NGX_ERROR;
++    }
++
++    return rc;
  }
-
-
+ 
+ 
 -static ngx_int_t
 -ngx_http_lua_balancer_by_chunk(lua_State *L, ngx_http_request_t *r)
 +static void
@@ -475,17 +512,17 @@ index f71a3e00..0d403716 100644
 +    ngx_http_lua_balancer_keepalive_item_t     *item;
 +    ngx_http_lua_balancer_keepalive_pool_t     *cpool;
 +    ngx_http_lua_balancer_peer_data_t          *bp = data;
-
+ 
 -    /* init nginx context in Lua VM */
 -    ngx_http_lua_set_req(L, r);
 +    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
 +                   "lua balancer: free peer, tries: %ui", pc->tries);
-
+ 
 -#ifndef OPENRESTY_LUAJIT
 -    ngx_http_lua_create_new_globals_table(L, 0 /* narr */, 1 /* nrec */);
 +    u = bp->request->upstream;
 +    c = pc->connection;
-
+ 
 -    /*  {{{ make new env inheriting main thread's globals table */
 -    lua_createtable(L, 0, 1 /* nrec */);   /* the metatable for the new env */
 -    ngx_http_lua_get_globals_table(L);
@@ -494,18 +531,18 @@ index f71a3e00..0d403716 100644
 -    /*  }}} */
 +    if (ngx_http_lua_balancer_peer_set(bp)) {
 +        bp->last_peer_state = (int) state;
-
+ 
 -    lua_setfenv(L, -2);    /*  set new running env for the code closure */
 -#endif /* OPENRESTY_LUAJIT */
 +        if (pc->tries) {
 +            pc->tries--;
 +        }
-
+ 
 -    lua_pushcfunction(L, ngx_http_lua_traceback);
 -    lua_insert(L, 1);  /* put it under chunk and args */
 +        if (ngx_http_lua_balancer_keepalive_is_enabled(bp)) {
 +            cpool = bp->cpool;
-
+ 
 -    /*  protected call user code */
 -    rc = lua_pcall(L, 0, 1, 1);
 +            if (state & NGX_PEER_FAILED
@@ -518,29 +555,21 @@ index f71a3e00..0d403716 100644
 +            {
 +                goto invalid;
 +            }
-
--    lua_remove(L, 1);  /* remove traceback function */
++
 +            if (bp->keepalive_requests
 +                && c->requests >= bp->keepalive_requests)
 +            {
 +                goto invalid;
 +            }
-
--    dd("rc == %d", (int) rc);
++
 +            if (!u->keepalive) {
 +                goto invalid;
 +            }
-
--    if (rc != 0) {
--        /*  error occurred when running loaded code */
--        err_msg = (u_char *) lua_tolstring(L, -1, &len);
++
 +            if (!u->request_body_sent) {
 +                goto invalid;
 +            }
-
--        if (err_msg == NULL) {
--            err_msg = (u_char *) "unknown reason";
--            len = sizeof("unknown reason") - 1;
++
 +            if (ngx_terminate || ngx_exiting) {
 +                goto invalid;
 +            }
@@ -617,59 +646,81 @@ index f71a3e00..0d403716 100644
 +            if (cpool->connections == 0) {
 +                ngx_http_lua_balancer_free_keepalive_pool(pc->log, cpool);
 +            }
-         }
-
--        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
--                      "failed to run balancer_by_lua*: %*s", len, err_msg);
++        }
+ 
+-    lua_remove(L, 1);  /* remove traceback function */
 +        return;
 +    }
-
--        lua_settop(L, 0); /*  clear remaining elems on stack */
+ 
+-    dd("rc == %d", (int) rc);
 +    bp->original_free_peer(pc, bp->data, state);
 +}
-+
-+
+ 
+-    if (rc != 0) {
+-        /*  error occurred when running loaded code */
+-        err_msg = (u_char *) lua_tolstring(L, -1, &len);
+ 
+-        if (err_msg == NULL) {
+-            err_msg = (u_char *) "unknown reason";
+-            len = sizeof("unknown reason") - 1;
+-        }
 +static ngx_int_t
 +ngx_http_lua_balancer_create_keepalive_pool(lua_State *L, ngx_log_t *log,
-+    uint32_t cpool_crc32, ngx_uint_t cpool_size,
++    //uint32_t cpool_crc32, ngx_uint_t cpool_size,
++    ngx_str_t *cpool_name, ngx_uint_t cpool_size,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool)
 +{
 +    size_t                                       size;
 +    ngx_uint_t                                   i;
 +    ngx_http_lua_balancer_keepalive_pool_t      *upool;
 +    ngx_http_lua_balancer_keepalive_item_t      *items;
-+
+ 
+-        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+-                      "failed to run balancer_by_lua*: %*s", len, err_msg);
 +    /* get upstream connection pools table */
 +    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
 +                          balancer_keepalive_pools_table_key));
 +    lua_rawget(L, LUA_REGISTRYINDEX); /* pools? */
-+
+ 
+-        lua_settop(L, 0); /*  clear remaining elems on stack */
 +    ngx_http_lua_assert(lua_istable(L, -1));
++
++    lua_pushlstring(L, cpool_name->data, cpool_name->len);
 +
 +    size = sizeof(ngx_http_lua_balancer_keepalive_pool_t)
 +           + sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size;
-
+ 
 +    upool = lua_newuserdata(L, size); /* pools upool */
 +    if (upool == NULL) {
          return NGX_ERROR;
      }
-
+ 
 -    lua_settop(L, 0); /*  clear remaining elems on stack */
 -    return rc;
-+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive create pool, crc32: %ui, "
-+                   "size: %ui", cpool_crc32, cpool_size);
++    //ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
++    //               "lua balancer: keepalive create pool, crc32: %ui, "
++    //               "size: %ui", cpool_crc32, cpool_size);
 +
 +    upool->lua_vm = L;
-+    upool->crc32 = cpool_crc32;
++    //upool->crc32 = cpool_crc32;
 +    upool->size = cpool_size;
 +    upool->connections = 0;
 +
 +    ngx_queue_init(&upool->cache);
 +    ngx_queue_init(&upool->free);
 +
-+    lua_rawseti(L, -2, cpool_crc32); /* pools */
-+    lua_pop(L, 1); /* orig stack */
++    lua_rawset(L, -3);
++
++    upool->cpool_name.data = lua_newuserdata(L, cpool_name->len);
++    if (upool->cpool_name.data == NULL) {
++        return NGX_ERROR;
++    }
++
++    ngx_memcpy(upool->cpool_name.data, cpool_name->data, cpool_name->len);
++    upool->cpool_name.len = cpool_name->len;
++
++    //lua_rawseti(L, -2, cpool_crc32); /* pools */
++    //lua_pop(L, 1); /* orig stack */
 +
 +    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
 +
@@ -684,25 +735,31 @@ index f71a3e00..0d403716 100644
 +
 +    return NGX_OK;
  }
-
-
+ 
+ 
  static void
 -ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
 -    ngx_uint_t state)
-+ngx_http_lua_balancer_get_keepalive_pool(lua_State *L, uint32_t cpool_crc32,
++ngx_http_lua_balancer_get_keepalive_pool(lua_State *L, ngx_str_t *cpool_name,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool)
  {
 -    ngx_http_lua_balancer_peer_data_t  *bp = data;
 +    ngx_http_lua_balancer_keepalive_pool_t      *upool;
-+
+ 
+-    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
+-                   "lua balancer free peer, tries: %ui", pc->tries);
 +    /* get upstream connection pools table */
 +    lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
 +                          balancer_keepalive_pools_table_key));
 +    lua_rawget(L, LUA_REGISTRYINDEX); /* pools? */
-+
+ 
+-    if (bp->sockaddr && bp->socklen) {
+-        bp->last_peer_state = (int) state;
 +    if (lua_isnil(L, -1)) {
 +        lua_pop(L, 1); /* orig stack */
-+
+ 
+-        if (pc->tries) {
+-            pc->tries--;
 +        /* create upstream connection pools table */
 +        lua_createtable(L, 0, 0); /* pools */
 +        lua_pushlightuserdata(L, ngx_http_lua_lightudata_mask(
@@ -710,19 +767,17 @@ index f71a3e00..0d403716 100644
 +        lua_pushvalue(L, -2); /* pools pools_table_key pools */
 +        lua_rawset(L, LUA_REGISTRYINDEX); /* pools */
 +    }
-
--    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
--                   "lua balancer free peer, tries: %ui", pc->tries);
++
 +    ngx_http_lua_assert(lua_istable(L, -1));
-
--    if (bp->sockaddr && bp->socklen) {
--        bp->last_peer_state = (int) state;
-+    lua_rawgeti(L, -1, cpool_crc32); /* pools upool? */
++
++    lua_pushlstring(L, cpool_name->data, cpool_name->len);
++    lua_rawget(L, -2);
++
++    //lua_rawgeti(L, -1, cpool_crc32); /* pools upool? */
++
 +    upool = lua_touserdata(L, -1);
 +    lua_pop(L, 2); /* orig stack */
-
--        if (pc->tries) {
--            pc->tries--;
++
 +    *cpool = upool;
 +}
 +
@@ -733,9 +788,9 @@ index f71a3e00..0d403716 100644
 +{
 +    lua_State                             *L;
 +
-+    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive free pool %p, crc32: %ui",
-+                   cpool, cpool->crc32);
++    //ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
++    //               "lua balancer: keepalive free pool %p, crc32: %ui",
++    //               cpool, cpool->crc32);
 +
 +    ngx_http_lua_assert(cpool->connections == 0);
 +
@@ -753,8 +808,13 @@ index f71a3e00..0d403716 100644
 +
 +    ngx_http_lua_assert(lua_istable(L, -1));
 +
++    lua_pushlstring(L, cpool->cpool_name.data, cpool->cpool_name.len);
 +    lua_pushnil(L); /* pools nil */
-+    lua_rawseti(L, -2, cpool->crc32); /* pools */
++    lua_rawset(L, -3); /* pools */
++
++    //lua_pushnil(L); /* pools nil */
++    //lua_rawseti(L, -2, cpool->crc32); /* pools */
++
 +    lua_pop(L, 1); /* orig stack */
 +}
 +
@@ -821,19 +881,19 @@ index f71a3e00..0d403716 100644
 +        if (ngx_handle_read_event(c->read, 0) != NGX_OK) {
 +            goto close;
          }
-
+ 
          return;
      }
-
+ 
 -    /* fallback */
 +close:
-+
+ 
+-    ngx_http_upstream_free_round_robin_peer(pc, data, state);
 +    item = c->data;
 +    c->log = ev->log;
 +
 +    ngx_http_lua_balancer_close(c);
-
--    ngx_http_upstream_free_round_robin_peer(pc, data, state);
++
 +    ngx_queue_remove(&item->queue);
 +    ngx_queue_insert_head(&item->cpool->free, &item->queue);
 +
@@ -841,45 +901,46 @@ index f71a3e00..0d403716 100644
 +        ngx_http_lua_balancer_free_keepalive_pool(ev->log, item->cpool);
 +    }
  }
-
-
-@@ -431,12 +874,12 @@ ngx_http_lua_balancer_set_session(ngx_peer_connection_t *pc, void *data)
+ 
+ 
+@@ -431,12 +936,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
-
+ 
 -    if (bp->sockaddr && bp->socklen) {
 +    if (ngx_http_lua_balancer_peer_set(bp)) {
          /* TODO */
          return NGX_OK;
      }
-
+ 
 -    return ngx_http_upstream_set_round_robin_peer_session(pc, &bp->rrp);
 +    return bp->original_set_session(pc, bp->data);
  }
-
-
-@@ -445,13 +888,12 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
+ 
+ 
+@@ -445,13 +950,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
-
+ 
 -    if (bp->sockaddr && bp->socklen) {
 +    if (ngx_http_lua_balancer_peer_set(bp)) {
          /* TODO */
          return;
      }
-
+ 
 -    ngx_http_upstream_save_round_robin_peer_session(pc, &bp->rrp);
 -    return;
 +    bp->original_save_session(pc, bp->data);
  }
-
+ 
  #endif
-@@ -459,14 +901,14 @@ ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc, void *data)
-
+@@ -459,14 +963,14 @@
+ 
  int
  ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
 -    const u_char *addr, size_t addr_len, int port, char **err)
-+    const u_char *addr, size_t addr_len, int port, unsigned int cpool_crc32,
++    const u_char *addr, size_t addr_len, int port,
++    const u_char *cpool_name, size_t cpool_name_len,
 +    unsigned int cpool_size, char **err)
  {
 -    ngx_url_t              url;
@@ -891,16 +952,58 @@ index f71a3e00..0d403716 100644
 +    ngx_url_t                                url;
 +    ngx_http_upstream_t                     *u;
 +    ngx_http_lua_ctx_t                      *ctx;
-+    ngx_http_lua_main_conf_t                *lmcf;
 +    ngx_http_lua_balancer_peer_data_t       *bp;
-
+ 
      if (r == NULL) {
          *err = "no request found";
-@@ -536,6 +978,70 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
+@@ -491,18 +995,6 @@
          return NGX_ERROR;
      }
-
-+    bp->cpool_crc32 = (uint32_t) cpool_crc32;
+ 
+-    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
+-
+-    /* we cannot read r->upstream->peer.data here directly because
+-     * it could be overridden by other modules like
+-     * ngx_http_upstream_keepalive_module.
+-     */
+-    bp = lmcf->balancer_peer_data;
+-    if (bp == NULL) {
+-        *err = "no upstream peer data found";
+-        return NGX_ERROR;
+-    }
+-
+     ngx_memzero(&url, sizeof(ngx_url_t));
+ 
+     url.url.data = ngx_palloc(r->pool, addr_len);
+@@ -526,6 +1018,8 @@
+         return NGX_ERROR;
+     }
+ 
++    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
++
+     if (url.addrs && url.addrs[0].sockaddr) {
+         bp->sockaddr = url.addrs[0].sockaddr;
+         bp->socklen = url.addrs[0].socklen;
+@@ -536,6 +1030,78 @@
+         return NGX_ERROR;
+     }
+ 
++    //bp->cpool_crc32 = (uint32_t) cpool_crc32;
++
++    if (cpool_name_len == 0) {
++        bp->cpool_name = bp->host;
++
++    } else {
++        bp->cpool_name = ngx_palloc(r->pool, cpool_name_len);
++        if (bp->cpool_name == NULL) {
++            *err = "no memory";
++            return NGX_ERROR;
++        }
++
++        ngx_memcpy(bp->cpool_name, cpool_name, cpool_name_len);
++    }
++
++
 +    bp->cpool_size = (ngx_uint_t) cpool_size;
 +
 +    return NGX_OK;
@@ -913,7 +1016,6 @@ index f71a3e00..0d403716 100644
 +{
 +    ngx_http_upstream_t                     *u;
 +    ngx_http_lua_ctx_t                      *ctx;
-+    ngx_http_lua_main_conf_t                *lmcf;
 +    ngx_http_lua_balancer_peer_data_t       *bp;
 +
 +    if (r == NULL) {
@@ -939,25 +1041,19 @@ index f71a3e00..0d403716 100644
 +        return NGX_ERROR;
 +    }
 +
-+    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
-+
-+    /* we cannot read r->upstream->peer.data here directly because
-+     * it could be overridden by other modules like
-+     * ngx_http_upstream_keepalive_module.
-+     */
-+    bp = lmcf->balancer_peer_data;
-+    if (bp == NULL) {
-+        *err = "no upstream peer data found";
-+        return NGX_ERROR;
-+    }
++    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
 +
 +    if (!ngx_http_lua_balancer_peer_set(bp)) {
 +        *err = "no current peer set";
 +        return NGX_ERROR;
 +    }
 +
-+    if (!bp->cpool_crc32) {
-+        bp->cpool_crc32 = ngx_crc32_long(bp->host->data, bp->host->len);
++    //if (!bp->cpool_crc32) {
++    //    bp->cpool_crc32 = ngx_crc32_long(bp->host->data, bp->host->len);
++    //}
++
++    if (!bp->cpool_name) {
++        bp->cpool_name = bp->host;
 +    }
 +
 +    bp->keepalive_timeout = (ngx_msec_t) timeout;
@@ -966,240 +1062,8 @@ index f71a3e00..0d403716 100644
 +
      return NGX_OK;
  }
-
-diff --git a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_http_lua_common.h
-index 781a2454..9ce6836a 100644
---- a/ngx_lua-0.10.21/src/ngx_http_lua_common.h
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_common.h
-@@ -328,6 +328,10 @@ union ngx_http_lua_srv_conf_u {
- #endif
-
-     struct {
-+        ngx_http_upstream_init_pt            original_init_upstream;
-+        ngx_http_upstream_init_peer_pt       original_init_peer;
-+        uintptr_t                            data;
-+
-         ngx_http_lua_srv_conf_handler_pt     handler;
-         ngx_str_t                            src;
-         u_char                              *src_key;
-diff --git a/ngx_lua-0.10.21/src/ngx_http_lua_module.c b/ngx_lua-0.10.21/src/ngx_http_lua_module.c
-index 9816d864..5d7cedfd 100644
---- a/ngx_lua-0.10.21/src/ngx_http_lua_module.c
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c
-@@ -1117,6 +1117,9 @@ ngx_http_lua_create_srv_conf(ngx_conf_t *cf)
-      *      lscf->srv.ssl_session_fetch_src = { 0, NULL };
-      *      lscf->srv.ssl_session_fetch_src_key = NULL;
-      *
-+     *      lscf->balancer.original_init_upstream = NULL;
-+     *      lscf->balancer.original_init_peer = NULL;
-+     *      lscf->balancer.data = NULL;
-      *      lscf->balancer.handler = NULL;
-      *      lscf->balancer.src = { 0, NULL };
-      *      lscf->balancer.src_key = NULL;
---
-2.26.2
-
-
-From 4c5cb29a265b2f9524434322adf15d07deec6c7f Mon Sep 17 00:00:00 2001
-From: Thibault Charbonnier <thibaultcha@me.com>
-Date: Tue, 17 Sep 2019 11:43:54 -0700
-Subject: [PATCH 2/3] feature: we now avoid the need for 'upstream' blocks to
- define a stub 'server' directive when using 'balancer_by_lua*'.
-
----
- src/ngx_http_lua_balancer.c | 42 +++++++++++++++++++++++++++++++++++--
- 1 file changed, 40 insertions(+), 2 deletions(-)
-
-diff --git a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
-index 0d403716..5c862d22 100644
---- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
-@@ -111,7 +111,8 @@ static void ngx_http_lua_balancer_save_session(ngx_peer_connection_t *pc,
-     (bp->sockaddr && bp->socklen)
-
-
--static char ngx_http_lua_balancer_keepalive_pools_table_key;
-+static char              ngx_http_lua_balancer_keepalive_pools_table_key;
-+static struct sockaddr  *ngx_http_lua_balancer_default_server_sockaddr;
-
-
- ngx_int_t
-@@ -239,7 +240,9 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
-     u_char                            *cache_key = NULL;
-     u_char                            *name;
-     ngx_str_t                         *value;
-+    ngx_url_t                          url;
-     ngx_http_upstream_srv_conf_t      *uscf;
-+    ngx_http_upstream_server_t        *us;
-     ngx_http_lua_srv_conf_t           *lscf = conf;
-
-     dd("enter");
-@@ -293,6 +296,29 @@ ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
-
-     uscf = ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module);
-
-+    if (uscf->servers->nelts == 0) {
-+        us = ngx_array_push(uscf->servers);
-+        if (us == NULL) {
-+            return NGX_CONF_ERROR;
-+        }
-+
-+        ngx_memzero(us, sizeof(ngx_http_upstream_server_t));
-+        ngx_memzero(&url, sizeof(ngx_url_t));
-+
-+        ngx_str_set(&url.url, "0.0.0.1");
-+        url.default_port = 80;
-+
-+        if (ngx_parse_url(cf->pool, &url) != NGX_OK) {
-+            return NGX_CONF_ERROR;
-+        }
-+
-+        us->name = url.url;
-+        us->addrs = url.addrs;
-+        us->naddrs = url.naddrs;
-+
-+        ngx_http_lua_balancer_default_server_sockaddr = us->addrs[0].sockaddr;
-+    }
-+
-     if (uscf->peer.init_upstream) {
-         ngx_conf_log_error(NGX_LOG_WARN, cf, 0,
-                            "load balancing method redefined");
-@@ -525,7 +551,19 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
-         return NGX_OK;
-     }
-
--    return bp->original_get_peer(pc, bp->data);
-+    rc = bp->original_get_peer(pc, bp->data);
-+    if (rc == NGX_ERROR) {
-+        return rc;
-+    }
-+
-+    if (pc->sockaddr == ngx_http_lua_balancer_default_server_sockaddr) {
-+        ngx_log_error(NGX_LOG_ERR, pc->log, 0,
-+                      "lua balancer: no peer set");
-+
-+        return NGX_ERROR;
-+    }
-+
-+    return rc;
- }
-
-
---
-2.26.2
-
-
-From 941cd893573561574bc6a326d6306f1a30127293 Mon Sep 17 00:00:00 2001
-From: Thibault Charbonnier <thibaultcha@me.com>
-Date: Tue, 17 Sep 2019 11:43:58 -0700
-Subject: [PATCH 3/3] refactor: used a simpler way to stash the balancer peer
- data.
-
----
- src/ngx_http_lua_balancer.c | 91 +++++++++----------------------------
- src/ngx_http_lua_common.h   |  7 ---
- 2 files changed, 22 insertions(+), 76 deletions(-)
-
-diff --git a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
-index 5c862d22..3ea1f067 100644
---- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
-@@ -411,9 +411,9 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
-     ngx_http_request_t                     *r;
-     ngx_http_lua_ctx_t                     *ctx;
-     ngx_http_lua_srv_conf_t                *lscf;
--    ngx_http_lua_main_conf_t               *lmcf;
-     ngx_http_lua_balancer_keepalive_item_t *item;
-     ngx_http_lua_balancer_peer_data_t      *bp = data;
-+    void                                   *pdata;
-
-     ngx_log_debug1(NGX_LOG_DEBUG_HTTP, pc->log, 0,
-                    "lua balancer: get peer, tries: %ui", pc->tries);
-@@ -452,15 +452,13 @@ ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
-     bp->keepalive = 0;
-     bp->total_tries++;
-
--    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
--
--    /* balancer_by_lua does not support yielding and
--     * there cannot be any conflicts among concurrent requests,
--     * thus it is safe to store the peer data in the main conf.
--     */
--    lmcf->balancer_peer_data = bp;
-+    pdata = r->upstream->peer.data;
-+    r->upstream->peer.data = bp;
-
-     rc = lscf->balancer.handler(r, lscf, L);
-+
-+    r->upstream->peer.data = pdata;
-+
-     if (rc == NGX_ERROR) {
-         return NGX_ERROR;
-     }
-@@ -945,7 +943,6 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
-     ngx_url_t                                url;
-     ngx_http_upstream_t                     *u;
-     ngx_http_lua_ctx_t                      *ctx;
--    ngx_http_lua_main_conf_t                *lmcf;
-     ngx_http_lua_balancer_peer_data_t       *bp;
-
-     if (r == NULL) {
-@@ -971,18 +968,6 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
-         return NGX_ERROR;
-     }
-
--    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
--
--    /* we cannot read r->upstream->peer.data here directly because
--     * it could be overridden by other modules like
--     * ngx_http_upstream_keepalive_module.
--     */
--    bp = lmcf->balancer_peer_data;
--    if (bp == NULL) {
--        *err = "no upstream peer data found";
--        return NGX_ERROR;
--    }
--
-     ngx_memzero(&url, sizeof(ngx_url_t));
-
-     url.url.data = ngx_palloc(r->pool, addr_len);
-@@ -1006,6 +991,8 @@ ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
-         return NGX_ERROR;
-     }
-
-+    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
-+
-     if (url.addrs && url.addrs[0].sockaddr) {
-         bp->sockaddr = url.addrs[0].sockaddr;
-         bp->socklen = url.addrs[0].socklen;
-@@ -1029,7 +1016,6 @@ ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
- {
-     ngx_http_upstream_t                     *u;
-     ngx_http_lua_ctx_t                      *ctx;
--    ngx_http_lua_main_conf_t                *lmcf;
-     ngx_http_lua_balancer_peer_data_t       *bp;
-
-     if (r == NULL) {
-@@ -1055,17 +1041,7 @@ ngx_http_lua_ffi_balancer_enable_keepalive(ngx_http_request_t *r,
-         return NGX_ERROR;
-     }
-
--    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
--
--    /* we cannot read r->upstream->peer.data here directly because
--     * it could be overridden by other modules like
--     * ngx_http_upstream_keepalive_module.
--     */
--    bp = lmcf->balancer_peer_data;
--    if (bp == NULL) {
--        *err = "no upstream peer data found";
--        return NGX_ERROR;
--    }
-+    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
-
-     if (!ngx_http_lua_balancer_peer_set(bp)) {
-         *err = "no current peer set";
-@@ -1089,14 +1065,13 @@ ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
+ 
+@@ -545,14 +1111,13 @@
      long connect_timeout, long send_timeout, long read_timeout,
      char **err)
  {
@@ -1207,20 +1071,20 @@ index 5c862d22..3ea1f067 100644
 -    ngx_http_upstream_t   *u;
 +    ngx_http_lua_ctx_t                 *ctx;
 +    ngx_http_upstream_t                *u;
-
+ 
  #if !(HAVE_NGX_UPSTREAM_TIMEOUT_FIELDS)
      ngx_http_upstream_conf_t           *ucf;
 -#endif
 -    ngx_http_lua_main_conf_t           *lmcf;
      ngx_http_lua_balancer_peer_data_t  *bp;
 +#endif
-
+ 
      if (r == NULL) {
          *err = "no request found";
-@@ -1121,15 +1096,9 @@ ngx_http_lua_ffi_balancer_set_timeouts(ngx_http_request_t *r,
+@@ -577,15 +1142,9 @@
          return NGX_ERROR;
      }
-
+ 
 -    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 -
 -    bp = lmcf->balancer_peer_data;
@@ -1235,7 +1099,7 @@ index 5c862d22..3ea1f067 100644
      if (!bp->cloned_upstream_conf) {
          /* we clone the upstream conf for the current request so that
           * we do not affect other requests at all. */
-@@ -1184,12 +1153,10 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
+@@ -640,12 +1199,10 @@
      int count, char **err)
  {
  #if (nginx_version >= 1007005)
@@ -1249,12 +1113,12 @@ index 5c862d22..3ea1f067 100644
 +    ngx_http_lua_ctx_t                 *ctx;
 +    ngx_http_upstream_t                *u;
      ngx_http_lua_balancer_peer_data_t  *bp;
-
+ 
      if (r == NULL) {
-@@ -1215,13 +1182,7 @@ ngx_http_lua_ffi_balancer_set_more_tries(ngx_http_request_t *r,
+@@ -671,13 +1228,7 @@
          return NGX_ERROR;
      }
-
+ 
 -    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 -
 -    bp = lmcf->balancer_peer_data;
@@ -1263,10 +1127,10 @@ index 5c862d22..3ea1f067 100644
 -        return NGX_ERROR;
 -    }
 +    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
-
+ 
  #if (nginx_version >= 1007005)
      max_tries = r->upstream->conf->next_upstream_tries;
-@@ -1247,12 +1208,10 @@ int
+@@ -703,12 +1254,10 @@
  ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
      int *status, char **err)
  {
@@ -1279,13 +1143,13 @@ index 5c862d22..3ea1f067 100644
 +    ngx_http_upstream_state_t          *state;
      ngx_http_lua_balancer_peer_data_t  *bp;
 -    ngx_http_lua_main_conf_t           *lmcf;
-
+ 
      if (r == NULL) {
          *err = "no request found";
-@@ -1277,13 +1236,7 @@ ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
+@@ -733,13 +1282,7 @@
          return NGX_ERROR;
      }
-
+ 
 -    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
 -
 -    bp = lmcf->balancer_peer_data;
@@ -1294,17 +1158,16 @@ index 5c862d22..3ea1f067 100644
 -        return NGX_ERROR;
 -    }
 +    bp = (ngx_http_lua_balancer_peer_data_t *) u->peer.data;
-
+ 
      if (r->upstream_states && r->upstream_states->nelts > 1) {
          state = r->upstream_states->elts;
-diff --git a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_http_lua_common.h
-index 9ce6836a..9a4342df 100644
---- a/ngx_lua-0.10.21/src/ngx_http_lua_common.h
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_common.h
-@@ -240,13 +240,6 @@ struct ngx_http_lua_main_conf_s {
+diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_http_lua_common.h
+--- a/ngx_lua-0.10.21/src/ngx_http_lua_common.h	2022-12-02 10:58:50.050203715 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_common.h	2022-12-02 12:02:18.661765557 +0800
+@@ -240,13 +240,6 @@
      ngx_http_lua_main_conf_handler_pt    exit_worker_handler;
      ngx_str_t                            exit_worker_src;
-
+ 
 -    ngx_http_lua_balancer_peer_data_t      *balancer_peer_data;
 -                    /* neither yielding nor recursion is possible in
 -                     * balancer_by_lua*, so there cannot be any races among
@@ -1315,5 +1178,27 @@ index 9ce6836a..9a4342df 100644
      ngx_chain_t                            *body_filter_chain;
                      /* neither yielding nor recursion is possible in
                       * body_filter_by_lua*, so there cannot be any races among
---
-2.26.2
+@@ -328,6 +321,10 @@
+ #endif
+ 
+     struct {
++        ngx_http_upstream_init_pt            original_init_upstream;
++        ngx_http_upstream_init_peer_pt       original_init_peer;
++        uintptr_t                            data;
++
+         ngx_http_lua_srv_conf_handler_pt     handler;
+         ngx_str_t                            src;
+         u_char                              *src_key;
+diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_module.c b/ngx_lua-0.10.21/src/ngx_http_lua_module.c
+--- a/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 10:58:50.050203715 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 12:02:15.121733885 +0800
+@@ -1117,6 +1117,9 @@
+      *      lscf->srv.ssl_session_fetch_src = { 0, NULL };
+      *      lscf->srv.ssl_session_fetch_src_key = NULL;
+      *
++     *      lscf->balancer.original_init_upstream = NULL;
++     *      lscf->balancer.original_init_peer = NULL;
++     *      lscf->balancer.data = NULL;
+      *      lscf->balancer.handler = NULL;
+      *      lscf->balancer.src = { 0, NULL };
+      *      lscf->balancer.src_key = NULL;

--- a/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -1,7 +1,7 @@
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 10:58:50.054203731 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 15:35:59.581735423 +0800
-@@ -16,46 +16,107 @@
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-03 08:44:03.223801483 +0800
+@@ -16,46 +16,108 @@
  #include "ngx_http_lua_directive.h"
  
  
@@ -103,7 +103,8 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool);
 +static void ngx_http_lua_balancer_get_keepalive_pool(lua_State *L,
 +    //uint32_t cpool_crc32, ngx_http_lua_balancer_keepalive_pool_t **cpool);
-+    ngx_str_t *cpool_name, ngx_http_lua_balancer_keepalive_pool_t **cpool);
++    ngx_log_t *log, ngx_str_t *cpool_name,
++    ngx_http_lua_balancer_keepalive_pool_t **cpool);
 +static void ngx_http_lua_balancer_free_keepalive_pool(ngx_log_t *log,
 +    ngx_http_lua_balancer_keepalive_pool_t *cpool);
 +static void ngx_http_lua_balancer_close(ngx_connection_t *c);
@@ -129,7 +130,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
  
  ngx_int_t
-@@ -102,6 +163,61 @@
+@@ -102,6 +164,61 @@
  }
  
  
@@ -191,7 +192,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  char *
  ngx_http_lua_balancer_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
      void *conf)
-@@ -125,16 +241,18 @@
+@@ -125,16 +242,18 @@
  ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
      void *conf)
  {
@@ -216,7 +217,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (cmd->post == NULL) {
          return NGX_CONF_ERROR;
      }
-@@ -178,11 +296,42 @@
+@@ -178,11 +297,42 @@
  
      lscf->balancer.src_key = cache_key;
  
@@ -259,7 +260,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      }
  
      uscf->peer.init_upstream = ngx_http_lua_balancer_init;
-@@ -198,14 +347,18 @@
+@@ -198,14 +348,18 @@
  
  
  static ngx_int_t
@@ -282,7 +283,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      us->peer.init = ngx_http_lua_balancer_init_peer;
  
      return NGX_OK;
-@@ -216,33 +369,38 @@
+@@ -216,33 +370,38 @@
  ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
      ngx_http_upstream_srv_conf_t *us)
  {
@@ -332,7 +333,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      return NGX_OK;
  }
  
-@@ -250,25 +408,26 @@
+@@ -250,25 +409,26 @@
  static ngx_int_t
  ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
  {
@@ -370,7 +371,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (ctx == NULL) {
          ctx = ngx_http_lua_create_ctx(r);
          if (ctx == NULL) {
-@@ -286,21 +445,24 @@
+@@ -286,21 +446,24 @@
  
      ctx->context = NGX_HTTP_LUA_CONTEXT_BALANCER;
  
@@ -402,7 +403,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (rc == NGX_ERROR) {
          return NGX_ERROR;
      }
-@@ -322,105 +484,450 @@
+@@ -322,105 +485,460 @@
          }
      }
  
@@ -423,7 +424,8 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
 -        dd("tries: %d", (int) r->upstream->peer.tries);
 +        if (ngx_http_lua_balancer_keepalive_is_enabled(bp)) {
-+            ngx_http_lua_balancer_get_keepalive_pool(L, &bp->cpool_name,
++            ngx_http_lua_balancer_get_keepalive_pool(L, pc->log,
++                                                     &bp->cpool_name,
 +                                                     &bp->cpool);
 +
 +            if (bp->cpool == NULL
@@ -684,12 +686,12 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
 -        lua_settop(L, 0); /*  clear remaining elems on stack */
 +    ngx_http_lua_assert(lua_istable(L, -1));
-+
-+    lua_pushlstring(L, cpool_name->data, cpool_name->len);
+ 
++    lua_pushlstring(L, (const char *)cpool_name->data, cpool_name->len);
 +
 +    size = sizeof(ngx_http_lua_balancer_keepalive_pool_t)
 +           + sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size;
- 
++
 +    upool = lua_newuserdata(L, size); /* pools upool */
 +    if (upool == NULL) {
          return NGX_ERROR;
@@ -697,9 +699,9 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
 -    lua_settop(L, 0); /*  clear remaining elems on stack */
 -    return rc;
-+    //ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-+    //               "lua balancer: keepalive create pool, crc32: %ui, "
-+    //               "size: %ui", cpool_crc32, cpool_size);
++    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
++                   "lua balancer: keepalive create pool, name: %V, "
++                   "size: %ui", cpool_name, cpool_size);
 +
 +    upool->lua_vm = L;
 +    //upool->crc32 = cpool_crc32;
@@ -742,7 +744,8 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  static void
 -ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc, void *data,
 -    ngx_uint_t state)
-+ngx_http_lua_balancer_get_keepalive_pool(lua_State *L, ngx_str_t *cpool_name,
++ngx_http_lua_balancer_get_keepalive_pool(lua_State *L,
++    ngx_log_t *log, ngx_str_t *cpool_name,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool)
  {
 -    ngx_http_lua_balancer_peer_data_t  *bp = data;
@@ -772,8 +775,12 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +
 +    ngx_http_lua_assert(lua_istable(L, -1));
 +
-+    lua_pushlstring(L, cpool_name->data, cpool_name->len);
++    lua_pushlstring(L, (const char *)cpool_name->data, cpool_name->len);
 +    lua_rawget(L, -2);
++
++    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
++                   "lua balancer: keepalive get pool, name: %V, ",
++                   cpool_name);
 +
 +    //lua_rawgeti(L, -1, cpool_crc32); /* pools upool? */
 +
@@ -810,9 +817,13 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +
 +    ngx_http_lua_assert(lua_istable(L, -1));
 +
-+    lua_pushlstring(L, cpool->cpool_name.data, cpool->cpool_name.len);
++    lua_pushlstring(L, (const char *)cpool->cpool_name.data, cpool->cpool_name.len);
 +    lua_pushnil(L); /* pools nil */
 +    lua_rawset(L, -3); /* pools */
++
++    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
++                   "lua balancer: keepalive free pool, name: %V, ",
++                   &cpool->cpool_name);
 +
 +    //lua_pushnil(L); /* pools nil */
 +    //lua_rawseti(L, -2, cpool->crc32); /* pools */
@@ -905,7 +916,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -431,12 +938,12 @@
+@@ -431,12 +949,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -920,7 +931,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -445,13 +952,12 @@
+@@ -445,13 +963,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -936,7 +947,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  #endif
-@@ -459,14 +965,14 @@
+@@ -459,14 +976,14 @@
  
  int
  ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
@@ -958,7 +969,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -491,18 +997,6 @@
+@@ -491,18 +1008,6 @@
          return NGX_ERROR;
      }
  
@@ -977,7 +988,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_memzero(&url, sizeof(ngx_url_t));
  
      url.url.data = ngx_palloc(r->pool, addr_len);
-@@ -526,6 +1020,8 @@
+@@ -526,6 +1031,8 @@
          return NGX_ERROR;
      }
  
@@ -986,7 +997,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (url.addrs && url.addrs[0].sockaddr) {
          bp->sockaddr = url.addrs[0].sockaddr;
          bp->socklen = url.addrs[0].socklen;
-@@ -536,6 +1032,79 @@
+@@ -536,6 +1043,79 @@
          return NGX_ERROR;
      }
  
@@ -1066,7 +1077,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      return NGX_OK;
  }
  
-@@ -545,14 +1114,13 @@
+@@ -545,14 +1125,13 @@
      long connect_timeout, long send_timeout, long read_timeout,
      char **err)
  {
@@ -1084,7 +1095,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -577,15 +1145,9 @@
+@@ -577,15 +1156,9 @@
          return NGX_ERROR;
      }
  
@@ -1102,7 +1113,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (!bp->cloned_upstream_conf) {
          /* we clone the upstream conf for the current request so that
           * we do not affect other requests at all. */
-@@ -640,12 +1202,10 @@
+@@ -640,12 +1213,10 @@
      int count, char **err)
  {
  #if (nginx_version >= 1007005)
@@ -1118,7 +1129,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_http_lua_balancer_peer_data_t  *bp;
  
      if (r == NULL) {
-@@ -671,13 +1231,7 @@
+@@ -671,13 +1242,7 @@
          return NGX_ERROR;
      }
  
@@ -1133,7 +1144,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
  #if (nginx_version >= 1007005)
      max_tries = r->upstream->conf->next_upstream_tries;
-@@ -703,12 +1257,10 @@
+@@ -703,12 +1268,10 @@
  ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
      int *status, char **err)
  {
@@ -1149,7 +1160,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -733,13 +1285,7 @@
+@@ -733,13 +1296,7 @@
          return NGX_ERROR;
      }
  
@@ -1194,7 +1205,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_
          u_char                              *src_key;
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_module.c b/ngx_lua-0.10.21/src/ngx_http_lua_module.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 10:58:50.050203715 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 15:35:59.581735423 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-03 08:44:03.223801483 +0800
 @@ -1117,6 +1117,9 @@
       *      lscf->srv.ssl_session_fetch_src = { 0, NULL };
       *      lscf->srv.ssl_session_fetch_src_key = NULL;

--- a/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -1,6 +1,6 @@
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 10:58:50.054203731 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-03 11:49:46.351574562 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-03 19:54:51.924714951 +0800
 @@ -16,46 +16,108 @@
  #include "ngx_http_lua_directive.h"
  
@@ -36,37 +36,37 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +
 +    ngx_uint_t                              more_tries;
 +    ngx_uint_t                              total_tries;
- 
--    ngx_http_lua_srv_conf_t            *conf;
--    ngx_http_request_t                 *request;
++
 +    int                                     last_peer_state;
- 
--    ngx_uint_t                          more_tries;
--    ngx_uint_t                          total_tries;
++
 +    //uint32_t                                cpool_crc32;
 +    ngx_str_t                               cpool_name;
  
--    struct sockaddr                    *sockaddr;
--    socklen_t                           socklen;
+-    ngx_http_lua_srv_conf_t            *conf;
+-    ngx_http_request_t                 *request;
 +    void                                   *data;
  
--    ngx_str_t                          *host;
--    in_port_t                           port;
+-    ngx_uint_t                          more_tries;
+-    ngx_uint_t                          total_tries;
 +    ngx_event_get_peer_pt                   original_get_peer;
 +    ngx_event_free_peer_pt                  original_free_peer;
-+
+ 
+-    struct sockaddr                    *sockaddr;
+-    socklen_t                           socklen;
 +#if (NGX_HTTP_SSL)
 +    ngx_event_set_peer_session_pt           original_set_session;
 +    ngx_event_save_peer_session_pt          original_save_session;
 +#endif
- 
--    int                                 last_peer_state;
++
 +    ngx_http_request_t                     *request;
 +    ngx_http_lua_srv_conf_t                *conf;
 +    ngx_http_lua_balancer_keepalive_pool_t *cpool;
-+
+ 
+-    ngx_str_t                          *host;
+-    in_port_t                           port;
 +    ngx_str_t                              *host;
-+
+ 
+-    int                                 last_peer_state;
 +    struct sockaddr                        *sockaddr;
 +    socklen_t                               socklen;
 +
@@ -371,7 +371,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (ctx == NULL) {
          ctx = ngx_http_lua_create_ctx(r);
          if (ctx == NULL) {
-@@ -286,21 +446,24 @@
+@@ -286,21 +446,26 @@
  
      ctx->context = NGX_HTTP_LUA_CONTEXT_BALANCER;
  
@@ -387,7 +387,8 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      bp->total_tries++;
  
 -    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
--
++    ngx_str_null(&bp->cpool_name);
+ 
 -    /* balancer_by_lua does not support yielding and
 -     * there cannot be any conflicts among concurrent requests,
 -     * thus it is safe to store the peer data in the main conf.
@@ -403,7 +404,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (rc == NGX_ERROR) {
          return NGX_ERROR;
      }
-@@ -322,105 +485,456 @@
+@@ -322,105 +487,455 @@
          }
      }
  
@@ -689,10 +690,10 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
 +    lua_pushlstring(L, (const char *)cpool_name->data, cpool_name->len);
 +
-+    size = sizeof(ngx_http_lua_balancer_keepalive_pool_t)
-+           + sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size;
++    size = sizeof(ngx_http_lua_balancer_keepalive_pool_t) +
++           sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size;
 +
-+    upool = lua_newuserdata(L, size); /* pools upool */
++    upool = lua_newuserdata(L, size + cpool_name->len); /* pools upool */
 +    if (upool == NULL) {
          return NGX_ERROR;
      }
@@ -700,35 +701,32 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 -    lua_settop(L, 0); /*  clear remaining elems on stack */
 -    return rc;
 +    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive create pool, name: %V, "
-+                   "size: %ui", cpool_name, cpool_size);
++                   "lua balancer: keepalive create pool, "
++                   "name: %V, size: %ui",
++                   cpool_name, cpool_size);
 +
 +    upool->lua_vm = L;
 +    //upool->crc32 = cpool_crc32;
 +    upool->size = cpool_size;
 +    upool->connections = 0;
 +
++    upool->cpool_name.len = cpool_name->len;
++    upool->cpool_name.data = (u_char *)(upool) + size;
++    ngx_memcpy(upool->cpool_name.data, cpool_name->data, cpool_name->len);
++
 +    ngx_queue_init(&upool->cache);
 +    ngx_queue_init(&upool->free);
 +
 +    lua_rawset(L, -3); /* pools */
-+
-+    upool->cpool_name.data = lua_newuserdata(L, cpool_name->len);
-+    if (upool->cpool_name.data == NULL) {
-+        return NGX_ERROR;
-+    }
-+
-+    ngx_memcpy(upool->cpool_name.data, cpool_name->data, cpool_name->len);
-+    upool->cpool_name.len = cpool_name->len;
-+
-+    lua_pop(L, 2); /* orig stack */
++    lua_pop(L, 1); /* orig stack */
 +
 +    //lua_rawseti(L, -2, cpool_crc32); /* pools */
 +    //lua_pop(L, 1); /* orig stack */
 +
 +    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
 +
-+    ngx_http_lua_assert((void *) items == ngx_align_ptr(items, NGX_ALIGNMENT));
++    // ???
++    //ngx_http_lua_assert((void *) items == ngx_align_ptr(items, NGX_ALIGNMENT));
 +
 +    for (i = 0; i < cpool_size; i++) {
 +        ngx_queue_insert_head(&upool->free, &items[i].queue);
@@ -778,14 +776,15 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    lua_pushlstring(L, (const char *)cpool_name->data, cpool_name->len);
 +    lua_rawget(L, -2);
 +
-+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive get pool, name: %V",
-+                   cpool_name);
-+
 +    //lua_rawgeti(L, -1, cpool_crc32); /* pools upool? */
 +
 +    upool = lua_touserdata(L, -1);
 +    lua_pop(L, 2); /* orig stack */
++
++    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
++                   "lua balancer: keepalive get pool, "
++                   "name: %V, cpool: %p",
++                   cpool_name, upool);
 +
 +    *cpool = upool;
 +}
@@ -796,10 +795,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    ngx_http_lua_balancer_keepalive_pool_t *cpool)
 +{
 +    lua_State                             *L;
-+
-+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive free pool, name: %V",
-+                   &cpool->cpool_name);
 +
 +    ngx_http_lua_assert(cpool->connections == 0);
 +
@@ -820,6 +815,11 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    lua_pushlstring(L, (const char *)cpool->cpool_name.data, cpool->cpool_name.len);
 +    lua_pushnil(L); /* pools nil */
 +    lua_rawset(L, -3); /* pools */
++
++    ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
++                   "lua balancer: keepalive free pool, "
++                   "name: %V, cpool: %p",
++                   &cpool->cpool_name, cpool);
 +
 +    //lua_pushnil(L); /* pools nil */
 +    //lua_rawseti(L, -2, cpool->crc32); /* pools */
@@ -896,13 +896,13 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
 -    /* fallback */
 +close:
-+
+ 
+-    ngx_http_upstream_free_round_robin_peer(pc, data, state);
 +    item = c->data;
 +    c->log = ev->log;
 +
 +    ngx_http_lua_balancer_close(c);
- 
--    ngx_http_upstream_free_round_robin_peer(pc, data, state);
++
 +    ngx_queue_remove(&item->queue);
 +    ngx_queue_insert_head(&item->cpool->free, &item->queue);
 +
@@ -912,7 +912,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -431,12 +945,12 @@
+@@ -431,12 +946,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -927,7 +927,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -445,13 +959,12 @@
+@@ -445,13 +960,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -943,7 +943,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  #endif
-@@ -459,14 +972,14 @@
+@@ -459,14 +973,14 @@
  
  int
  ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
@@ -965,7 +965,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -491,18 +1004,6 @@
+@@ -491,18 +1005,6 @@
          return NGX_ERROR;
      }
  
@@ -984,7 +984,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_memzero(&url, sizeof(ngx_url_t));
  
      url.url.data = ngx_palloc(r->pool, addr_len);
-@@ -526,6 +1027,8 @@
+@@ -526,6 +1028,8 @@
          return NGX_ERROR;
      }
  
@@ -993,7 +993,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (url.addrs && url.addrs[0].sockaddr) {
          bp->sockaddr = url.addrs[0].sockaddr;
          bp->socklen = url.addrs[0].socklen;
-@@ -536,6 +1039,79 @@
+@@ -536,6 +1040,79 @@
          return NGX_ERROR;
      }
  
@@ -1073,7 +1073,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      return NGX_OK;
  }
  
-@@ -545,14 +1121,13 @@
+@@ -545,14 +1122,13 @@
      long connect_timeout, long send_timeout, long read_timeout,
      char **err)
  {
@@ -1091,7 +1091,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -577,15 +1152,9 @@
+@@ -577,15 +1153,9 @@
          return NGX_ERROR;
      }
  
@@ -1109,7 +1109,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (!bp->cloned_upstream_conf) {
          /* we clone the upstream conf for the current request so that
           * we do not affect other requests at all. */
-@@ -640,12 +1209,10 @@
+@@ -640,12 +1210,10 @@
      int count, char **err)
  {
  #if (nginx_version >= 1007005)
@@ -1125,7 +1125,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_http_lua_balancer_peer_data_t  *bp;
  
      if (r == NULL) {
-@@ -671,13 +1238,7 @@
+@@ -671,13 +1239,7 @@
          return NGX_ERROR;
      }
  
@@ -1140,7 +1140,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
  #if (nginx_version >= 1007005)
      max_tries = r->upstream->conf->next_upstream_tries;
-@@ -703,12 +1264,10 @@
+@@ -703,12 +1265,10 @@
  ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
      int *status, char **err)
  {
@@ -1156,7 +1156,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -733,13 +1292,7 @@
+@@ -733,13 +1293,7 @@
          return NGX_ERROR;
      }
  
@@ -1173,7 +1173,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
          state = r->upstream_states->elts;
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_http_lua_common.h
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_common.h	2022-12-02 10:58:50.050203715 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_common.h	2022-12-02 12:02:18.661765557 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_common.h	2022-12-03 20:00:04.841112698 +0800
 @@ -240,13 +240,6 @@
      ngx_http_lua_main_conf_handler_pt    exit_worker_handler;
      ngx_str_t                            exit_worker_src;
@@ -1201,7 +1201,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_
          u_char                              *src_key;
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_module.c b/ngx_lua-0.10.21/src/ngx_http_lua_module.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 10:58:50.050203715 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-03 11:49:46.351574562 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-03 19:54:51.924714951 +0800
 @@ -1117,6 +1117,9 @@
       *      lscf->srv.ssl_session_fetch_src = { 0, NULL };
       *      lscf->srv.ssl_session_fetch_src_key = NULL;

--- a/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -1,7 +1,7 @@
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 10:58:50.054203731 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-03 19:54:51.924714951 +0800
-@@ -16,46 +16,108 @@
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-05 07:01:11.794290850 +0800
+@@ -16,46 +16,104 @@
  #include "ngx_http_lua_directive.h"
  
  
@@ -9,7 +9,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    ngx_uint_t                               size;
 +    ngx_uint_t                               connections;
 +
-+    //uint32_t                                 crc32;
 +    ngx_str_t                                cpool_name;
 +
 +    lua_State                               *lua_vm;
@@ -39,7 +38,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +
 +    int                                     last_peer_state;
 +
-+    //uint32_t                                cpool_crc32;
 +    ngx_str_t                               cpool_name;
  
 -    ngx_http_lua_srv_conf_t            *conf;
@@ -98,11 +96,9 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  static void ngx_http_lua_balancer_free_peer(ngx_peer_connection_t *pc,
      void *data, ngx_uint_t state);
 +static ngx_int_t ngx_http_lua_balancer_create_keepalive_pool(lua_State *L,
-+    //ngx_log_t *log, uint32_t cpool_crc32, ngx_uint_t cpool_size,
 +    ngx_log_t *log, ngx_str_t *cpool_name, ngx_uint_t cpool_size,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool);
 +static void ngx_http_lua_balancer_get_keepalive_pool(lua_State *L,
-+    //uint32_t cpool_crc32, ngx_http_lua_balancer_keepalive_pool_t **cpool);
 +    ngx_log_t *log, ngx_str_t *cpool_name,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool);
 +static void ngx_http_lua_balancer_free_keepalive_pool(ngx_log_t *log,
@@ -130,7 +126,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
  
  ngx_int_t
-@@ -102,6 +164,61 @@
+@@ -102,6 +160,61 @@
  }
  
  
@@ -192,7 +188,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  char *
  ngx_http_lua_balancer_by_lua_block(ngx_conf_t *cf, ngx_command_t *cmd,
      void *conf)
-@@ -125,16 +242,18 @@
+@@ -125,16 +238,18 @@
  ngx_http_lua_balancer_by_lua(ngx_conf_t *cf, ngx_command_t *cmd,
      void *conf)
  {
@@ -217,7 +213,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (cmd->post == NULL) {
          return NGX_CONF_ERROR;
      }
-@@ -178,11 +297,42 @@
+@@ -178,11 +293,42 @@
  
      lscf->balancer.src_key = cache_key;
  
@@ -260,7 +256,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      }
  
      uscf->peer.init_upstream = ngx_http_lua_balancer_init;
-@@ -198,14 +348,18 @@
+@@ -198,14 +344,18 @@
  
  
  static ngx_int_t
@@ -283,7 +279,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      us->peer.init = ngx_http_lua_balancer_init_peer;
  
      return NGX_OK;
-@@ -216,33 +370,38 @@
+@@ -216,33 +366,38 @@
  ngx_http_lua_balancer_init_peer(ngx_http_request_t *r,
      ngx_http_upstream_srv_conf_t *us)
  {
@@ -333,7 +329,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      return NGX_OK;
  }
  
-@@ -250,25 +409,26 @@
+@@ -250,25 +405,26 @@
  static ngx_int_t
  ngx_http_lua_balancer_get_peer(ngx_peer_connection_t *pc, void *data)
  {
@@ -371,7 +367,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (ctx == NULL) {
          ctx = ngx_http_lua_create_ctx(r);
          if (ctx == NULL) {
-@@ -286,21 +446,26 @@
+@@ -286,21 +442,23 @@
  
      ctx->context = NGX_HTTP_LUA_CONTEXT_BALANCER;
  
@@ -379,7 +375,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      bp->sockaddr = NULL;
      bp->socklen = 0;
      bp->more_tries = 0;
-+    //bp->cpool_crc32 = 0;
 +    bp->cpool_size = 0;
 +    bp->keepalive_requests = 0;
 +    bp->keepalive_timeout = 0;
@@ -387,8 +382,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      bp->total_tries++;
  
 -    lmcf = ngx_http_get_module_main_conf(r, ngx_http_lua_module);
-+    ngx_str_null(&bp->cpool_name);
- 
+-
 -    /* balancer_by_lua does not support yielding and
 -     * there cannot be any conflicts among concurrent requests,
 -     * thus it is safe to store the peer data in the main conf.
@@ -404,7 +398,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (rc == NGX_ERROR) {
          return NGX_ERROR;
      }
-@@ -322,105 +487,455 @@
+@@ -322,105 +480,445 @@
          }
      }
  
@@ -669,7 +663,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 -        }
 +static ngx_int_t
 +ngx_http_lua_balancer_create_keepalive_pool(lua_State *L, ngx_log_t *log,
-+    //uint32_t cpool_crc32, ngx_uint_t cpool_size,
 +    ngx_str_t *cpool_name, ngx_uint_t cpool_size,
 +    ngx_http_lua_balancer_keepalive_pool_t **cpool)
 +{
@@ -687,12 +680,12 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
 -        lua_settop(L, 0); /*  clear remaining elems on stack */
 +    ngx_http_lua_assert(lua_istable(L, -1));
- 
++
 +    lua_pushlstring(L, (const char *)cpool_name->data, cpool_name->len);
 +
 +    size = sizeof(ngx_http_lua_balancer_keepalive_pool_t) +
 +           sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size;
-+
+ 
 +    upool = lua_newuserdata(L, size + cpool_name->len); /* pools upool */
 +    if (upool == NULL) {
          return NGX_ERROR;
@@ -706,7 +699,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +                   cpool_name, cpool_size);
 +
 +    upool->lua_vm = L;
-+    //upool->crc32 = cpool_crc32;
 +    upool->size = cpool_size;
 +    upool->connections = 0;
 +
@@ -719,9 +711,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +
 +    lua_rawset(L, -3); /* pools */
 +    lua_pop(L, 1); /* orig stack */
-+
-+    //lua_rawseti(L, -2, cpool_crc32); /* pools */
-+    //lua_pop(L, 1); /* orig stack */
 +
 +    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
 +
@@ -776,8 +765,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    lua_pushlstring(L, (const char *)cpool_name->data, cpool_name->len);
 +    lua_rawget(L, -2);
 +
-+    //lua_rawgeti(L, -1, cpool_crc32); /* pools upool? */
-+
 +    upool = lua_touserdata(L, -1);
 +    lua_pop(L, 2); /* orig stack */
 +
@@ -820,9 +807,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +                   "lua balancer: keepalive free pool, "
 +                   "name: %V, cpool: %p",
 +                   &cpool->cpool_name, cpool);
-+
-+    //lua_pushnil(L); /* pools nil */
-+    //lua_rawseti(L, -2, cpool->crc32); /* pools */
 +
 +    lua_pop(L, 1); /* orig stack */
 +}
@@ -912,7 +896,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -431,12 +946,12 @@
+@@ -431,12 +929,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -927,7 +911,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -445,13 +960,12 @@
+@@ -445,13 +943,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -943,7 +927,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  #endif
-@@ -459,14 +973,14 @@
+@@ -459,14 +956,14 @@
  
  int
  ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
@@ -965,7 +949,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -491,18 +1005,6 @@
+@@ -491,18 +988,6 @@
          return NGX_ERROR;
      }
  
@@ -984,7 +968,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_memzero(&url, sizeof(ngx_url_t));
  
      url.url.data = ngx_palloc(r->pool, addr_len);
-@@ -526,6 +1028,8 @@
+@@ -526,6 +1011,8 @@
          return NGX_ERROR;
      }
  
@@ -993,12 +977,10 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (url.addrs && url.addrs[0].sockaddr) {
          bp->sockaddr = url.addrs[0].sockaddr;
          bp->socklen = url.addrs[0].socklen;
-@@ -536,6 +1040,79 @@
+@@ -536,6 +1023,73 @@
          return NGX_ERROR;
      }
  
-+    //bp->cpool_crc32 = (uint32_t) cpool_crc32;
-+
 +    if (cpool_name_len == 0) {
 +        bp->cpool_name = *bp->host;
 +
@@ -1058,10 +1040,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +        return NGX_ERROR;
 +    }
 +
-+    //if (!bp->cpool_crc32) {
-+    //    bp->cpool_crc32 = ngx_crc32_long(bp->host->data, bp->host->len);
-+    //}
-+
 +    if (!bp->cpool_name.data) {
 +        bp->cpool_name = *bp->host;
 +    }
@@ -1073,7 +1051,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      return NGX_OK;
  }
  
-@@ -545,14 +1122,13 @@
+@@ -545,14 +1099,13 @@
      long connect_timeout, long send_timeout, long read_timeout,
      char **err)
  {
@@ -1091,7 +1069,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -577,15 +1153,9 @@
+@@ -577,15 +1130,9 @@
          return NGX_ERROR;
      }
  
@@ -1109,7 +1087,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (!bp->cloned_upstream_conf) {
          /* we clone the upstream conf for the current request so that
           * we do not affect other requests at all. */
-@@ -640,12 +1210,10 @@
+@@ -640,12 +1187,10 @@
      int count, char **err)
  {
  #if (nginx_version >= 1007005)
@@ -1125,7 +1103,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_http_lua_balancer_peer_data_t  *bp;
  
      if (r == NULL) {
-@@ -671,13 +1239,7 @@
+@@ -671,13 +1216,7 @@
          return NGX_ERROR;
      }
  
@@ -1140,7 +1118,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
  #if (nginx_version >= 1007005)
      max_tries = r->upstream->conf->next_upstream_tries;
-@@ -703,12 +1265,10 @@
+@@ -703,12 +1242,10 @@
  ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
      int *status, char **err)
  {
@@ -1156,7 +1134,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -733,13 +1293,7 @@
+@@ -733,13 +1270,7 @@
          return NGX_ERROR;
      }
  
@@ -1173,7 +1151,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
          state = r->upstream_states->elts;
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_http_lua_common.h
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_common.h	2022-12-02 10:58:50.050203715 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_common.h	2022-12-03 20:00:04.841112698 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_common.h	2022-12-05 07:01:11.798290942 +0800
 @@ -240,13 +240,6 @@
      ngx_http_lua_main_conf_handler_pt    exit_worker_handler;
      ngx_str_t                            exit_worker_src;
@@ -1201,7 +1179,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_
          u_char                              *src_key;
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_module.c b/ngx_lua-0.10.21/src/ngx_http_lua_module.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 10:58:50.050203715 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-03 19:54:51.924714951 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-05 07:01:11.798290942 +0800
 @@ -1117,6 +1117,9 @@
       *      lscf->srv.ssl_session_fetch_src = { 0, NULL };
       *      lscf->srv.ssl_session_fetch_src_key = NULL;

--- a/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -1,6 +1,6 @@
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 10:58:50.054203731 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-03 08:44:03.223801483 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-03 11:49:46.351574562 +0800
 @@ -16,46 +16,108 @@
  #include "ngx_http_lua_directive.h"
  
@@ -403,7 +403,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (rc == NGX_ERROR) {
          return NGX_ERROR;
      }
-@@ -322,105 +485,460 @@
+@@ -322,105 +485,456 @@
          }
      }
  
@@ -779,7 +779,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    lua_rawget(L, -2);
 +
 +    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive get pool, name: %V, ",
++                   "lua balancer: keepalive get pool, name: %V",
 +                   cpool_name);
 +
 +    //lua_rawgeti(L, -1, cpool_crc32); /* pools upool? */
@@ -797,9 +797,9 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +{
 +    lua_State                             *L;
 +
-+    //ngx_log_debug2(NGX_LOG_DEBUG_HTTP, log, 0,
-+    //               "lua balancer: keepalive free pool %p, crc32: %ui",
-+    //               cpool, cpool->crc32);
++    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
++                   "lua balancer: keepalive free pool, name: %V",
++                   &cpool->cpool_name);
 +
 +    ngx_http_lua_assert(cpool->connections == 0);
 +
@@ -820,10 +820,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    lua_pushlstring(L, (const char *)cpool->cpool_name.data, cpool->cpool_name.len);
 +    lua_pushnil(L); /* pools nil */
 +    lua_rawset(L, -3); /* pools */
-+
-+    ngx_log_debug1(NGX_LOG_DEBUG_HTTP, log, 0,
-+                   "lua balancer: keepalive free pool, name: %V, ",
-+                   &cpool->cpool_name);
 +
 +    //lua_pushnil(L); /* pools nil */
 +    //lua_rawseti(L, -2, cpool->crc32); /* pools */
@@ -916,7 +912,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -431,12 +949,12 @@
+@@ -431,12 +945,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -931,7 +927,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -445,13 +963,12 @@
+@@ -445,13 +959,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -947,7 +943,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  #endif
-@@ -459,14 +976,14 @@
+@@ -459,14 +972,14 @@
  
  int
  ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
@@ -969,7 +965,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -491,18 +1008,6 @@
+@@ -491,18 +1004,6 @@
          return NGX_ERROR;
      }
  
@@ -988,7 +984,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_memzero(&url, sizeof(ngx_url_t));
  
      url.url.data = ngx_palloc(r->pool, addr_len);
-@@ -526,6 +1031,8 @@
+@@ -526,6 +1027,8 @@
          return NGX_ERROR;
      }
  
@@ -997,7 +993,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (url.addrs && url.addrs[0].sockaddr) {
          bp->sockaddr = url.addrs[0].sockaddr;
          bp->socklen = url.addrs[0].socklen;
-@@ -536,6 +1043,79 @@
+@@ -536,6 +1039,79 @@
          return NGX_ERROR;
      }
  
@@ -1077,7 +1073,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      return NGX_OK;
  }
  
-@@ -545,14 +1125,13 @@
+@@ -545,14 +1121,13 @@
      long connect_timeout, long send_timeout, long read_timeout,
      char **err)
  {
@@ -1095,7 +1091,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -577,15 +1156,9 @@
+@@ -577,15 +1152,9 @@
          return NGX_ERROR;
      }
  
@@ -1113,7 +1109,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (!bp->cloned_upstream_conf) {
          /* we clone the upstream conf for the current request so that
           * we do not affect other requests at all. */
-@@ -640,12 +1213,10 @@
+@@ -640,12 +1209,10 @@
      int count, char **err)
  {
  #if (nginx_version >= 1007005)
@@ -1129,7 +1125,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_http_lua_balancer_peer_data_t  *bp;
  
      if (r == NULL) {
-@@ -671,13 +1242,7 @@
+@@ -671,13 +1238,7 @@
          return NGX_ERROR;
      }
  
@@ -1144,7 +1140,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
  #if (nginx_version >= 1007005)
      max_tries = r->upstream->conf->next_upstream_tries;
-@@ -703,12 +1268,10 @@
+@@ -703,12 +1264,10 @@
  ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
      int *status, char **err)
  {
@@ -1160,7 +1156,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -733,13 +1296,7 @@
+@@ -733,13 +1292,7 @@
          return NGX_ERROR;
      }
  
@@ -1205,7 +1201,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_
          u_char                              *src_key;
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_module.c b/ngx_lua-0.10.21/src/ngx_http_lua_module.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 10:58:50.050203715 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-03 08:44:03.223801483 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-03 11:49:46.351574562 +0800
 @@ -1117,6 +1117,9 @@
       *      lscf->srv.ssl_session_fetch_src = { 0, NULL };
       *      lscf->srv.ssl_session_fetch_src_key = NULL;

--- a/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -1,6 +1,6 @@
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 10:58:50.054203731 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 14:09:20.504976137 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 15:35:59.581735423 +0800
 @@ -16,46 +16,107 @@
  #include "ngx_http_lua_directive.h"
  
@@ -402,7 +402,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (rc == NGX_ERROR) {
          return NGX_ERROR;
      }
-@@ -322,105 +484,448 @@
+@@ -322,105 +484,450 @@
          }
      }
  
@@ -709,7 +709,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    ngx_queue_init(&upool->cache);
 +    ngx_queue_init(&upool->free);
 +
-+    lua_rawset(L, -3);
++    lua_rawset(L, -3); /* pools */
 +
 +    upool->cpool_name.data = lua_newuserdata(L, cpool_name->len);
 +    if (upool->cpool_name.data == NULL) {
@@ -718,6 +718,8 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +
 +    ngx_memcpy(upool->cpool_name.data, cpool_name->data, cpool_name->len);
 +    upool->cpool_name.len = cpool_name->len;
++
++    lua_pop(L, 2); /* orig stack */
 +
 +    //lua_rawseti(L, -2, cpool_crc32); /* pools */
 +    //lua_pop(L, 1); /* orig stack */
@@ -887,13 +889,13 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
 -    /* fallback */
 +close:
- 
--    ngx_http_upstream_free_round_robin_peer(pc, data, state);
++
 +    item = c->data;
 +    c->log = ev->log;
 +
 +    ngx_http_lua_balancer_close(c);
-+
+ 
+-    ngx_http_upstream_free_round_robin_peer(pc, data, state);
 +    ngx_queue_remove(&item->queue);
 +    ngx_queue_insert_head(&item->cpool->free, &item->queue);
 +
@@ -903,7 +905,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -431,12 +936,12 @@
+@@ -431,12 +938,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -918,7 +920,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -445,13 +950,12 @@
+@@ -445,13 +952,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -934,7 +936,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  #endif
-@@ -459,14 +963,14 @@
+@@ -459,14 +965,14 @@
  
  int
  ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
@@ -956,7 +958,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -491,18 +995,6 @@
+@@ -491,18 +997,6 @@
          return NGX_ERROR;
      }
  
@@ -975,7 +977,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_memzero(&url, sizeof(ngx_url_t));
  
      url.url.data = ngx_palloc(r->pool, addr_len);
-@@ -526,6 +1018,8 @@
+@@ -526,6 +1020,8 @@
          return NGX_ERROR;
      }
  
@@ -984,7 +986,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (url.addrs && url.addrs[0].sockaddr) {
          bp->sockaddr = url.addrs[0].sockaddr;
          bp->socklen = url.addrs[0].socklen;
-@@ -536,6 +1030,79 @@
+@@ -536,6 +1032,79 @@
          return NGX_ERROR;
      }
  
@@ -1064,7 +1066,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      return NGX_OK;
  }
  
-@@ -545,14 +1112,13 @@
+@@ -545,14 +1114,13 @@
      long connect_timeout, long send_timeout, long read_timeout,
      char **err)
  {
@@ -1082,7 +1084,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -577,15 +1143,9 @@
+@@ -577,15 +1145,9 @@
          return NGX_ERROR;
      }
  
@@ -1100,7 +1102,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (!bp->cloned_upstream_conf) {
          /* we clone the upstream conf for the current request so that
           * we do not affect other requests at all. */
-@@ -640,12 +1200,10 @@
+@@ -640,12 +1202,10 @@
      int count, char **err)
  {
  #if (nginx_version >= 1007005)
@@ -1116,7 +1118,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_http_lua_balancer_peer_data_t  *bp;
  
      if (r == NULL) {
-@@ -671,13 +1229,7 @@
+@@ -671,13 +1231,7 @@
          return NGX_ERROR;
      }
  
@@ -1131,7 +1133,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
  #if (nginx_version >= 1007005)
      max_tries = r->upstream->conf->next_upstream_tries;
-@@ -703,12 +1255,10 @@
+@@ -703,12 +1257,10 @@
  ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
      int *status, char **err)
  {
@@ -1147,7 +1149,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -733,13 +1283,7 @@
+@@ -733,13 +1285,7 @@
          return NGX_ERROR;
      }
  
@@ -1192,7 +1194,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_
          u_char                              *src_key;
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_module.c b/ngx_lua-0.10.21/src/ngx_http_lua_module.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 10:58:50.050203715 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 14:09:20.504976137 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 15:35:59.581735423 +0800
 @@ -1117,6 +1117,9 @@
       *      lscf->srv.ssl_session_fetch_src = { 0, NULL };
       *      lscf->srv.ssl_session_fetch_src_key = NULL;

--- a/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
+++ b/openresty-patches/patches/1.21.4.1/ngx_lua-0.10.21_02-dyn_upstream_keepalive.patch
@@ -1,6 +1,6 @@
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-02 10:58:50.054203731 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-05 07:01:11.794290850 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c	2022-12-05 18:22:15.351308080 +0800
 @@ -16,46 +16,104 @@
  #include "ngx_http_lua_directive.h"
  
@@ -398,7 +398,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (rc == NGX_ERROR) {
          return NGX_ERROR;
      }
-@@ -322,105 +480,445 @@
+@@ -322,105 +480,444 @@
          }
      }
  
@@ -682,10 +682,10 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +    ngx_http_lua_assert(lua_istable(L, -1));
 +
 +    lua_pushlstring(L, (const char *)cpool_name->data, cpool_name->len);
-+
+ 
 +    size = sizeof(ngx_http_lua_balancer_keepalive_pool_t) +
 +           sizeof(ngx_http_lua_balancer_keepalive_item_t) * cpool_size;
- 
++
 +    upool = lua_newuserdata(L, size + cpool_name->len); /* pools upool */
 +    if (upool == NULL) {
          return NGX_ERROR;
@@ -714,8 +714,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +
 +    items = (ngx_http_lua_balancer_keepalive_item_t *) (&upool->free + 1);
 +
-+    // ???
-+    //ngx_http_lua_assert((void *) items == ngx_align_ptr(items, NGX_ALIGNMENT));
++    /*ngx_http_lua_assert((void *) items == ngx_align_ptr(items, NGX_ALIGNMENT));*/
 +
 +    for (i = 0; i < cpool_size; i++) {
 +        ngx_queue_insert_head(&upool->free, &items[i].queue);
@@ -880,13 +879,13 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
 -    /* fallback */
 +close:
- 
--    ngx_http_upstream_free_round_robin_peer(pc, data, state);
++
 +    item = c->data;
 +    c->log = ev->log;
 +
 +    ngx_http_lua_balancer_close(c);
-+
+ 
+-    ngx_http_upstream_free_round_robin_peer(pc, data, state);
 +    ngx_queue_remove(&item->queue);
 +    ngx_queue_insert_head(&item->cpool->free, &item->queue);
 +
@@ -896,7 +895,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -431,12 +929,12 @@
+@@ -431,12 +928,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -911,7 +910,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  
-@@ -445,13 +943,12 @@
+@@ -445,13 +942,12 @@
  {
      ngx_http_lua_balancer_peer_data_t  *bp = data;
  
@@ -927,7 +926,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  }
  
  #endif
-@@ -459,14 +956,14 @@
+@@ -459,14 +955,14 @@
  
  int
  ngx_http_lua_ffi_balancer_set_current_peer(ngx_http_request_t *r,
@@ -949,7 +948,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -491,18 +988,6 @@
+@@ -491,18 +987,6 @@
          return NGX_ERROR;
      }
  
@@ -968,7 +967,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_memzero(&url, sizeof(ngx_url_t));
  
      url.url.data = ngx_palloc(r->pool, addr_len);
-@@ -526,6 +1011,8 @@
+@@ -526,6 +1010,8 @@
          return NGX_ERROR;
      }
  
@@ -977,7 +976,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (url.addrs && url.addrs[0].sockaddr) {
          bp->sockaddr = url.addrs[0].sockaddr;
          bp->socklen = url.addrs[0].socklen;
-@@ -536,6 +1023,73 @@
+@@ -536,6 +1022,72 @@
          return NGX_ERROR;
      }
  
@@ -994,7 +993,6 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
 +        ngx_memcpy(bp->cpool_name.data, cpool_name, cpool_name_len);
 +        bp->cpool_name.len = cpool_name_len;
 +    }
-+
 +
 +    bp->cpool_size = (ngx_uint_t) cpool_size;
 +
@@ -1051,7 +1049,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      return NGX_OK;
  }
  
-@@ -545,14 +1099,13 @@
+@@ -545,14 +1097,13 @@
      long connect_timeout, long send_timeout, long read_timeout,
      char **err)
  {
@@ -1069,7 +1067,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -577,15 +1130,9 @@
+@@ -577,15 +1128,9 @@
          return NGX_ERROR;
      }
  
@@ -1087,7 +1085,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      if (!bp->cloned_upstream_conf) {
          /* we clone the upstream conf for the current request so that
           * we do not affect other requests at all. */
-@@ -640,12 +1187,10 @@
+@@ -640,12 +1185,10 @@
      int count, char **err)
  {
  #if (nginx_version >= 1007005)
@@ -1103,7 +1101,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
      ngx_http_lua_balancer_peer_data_t  *bp;
  
      if (r == NULL) {
-@@ -671,13 +1216,7 @@
+@@ -671,13 +1214,7 @@
          return NGX_ERROR;
      }
  
@@ -1118,7 +1116,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
  #if (nginx_version >= 1007005)
      max_tries = r->upstream->conf->next_upstream_tries;
-@@ -703,12 +1242,10 @@
+@@ -703,12 +1240,10 @@
  ngx_http_lua_ffi_balancer_get_last_failure(ngx_http_request_t *r,
      int *status, char **err)
  {
@@ -1134,7 +1132,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_balancer.c b/ngx_lua-0.10.21/src/ng
  
      if (r == NULL) {
          *err = "no request found";
-@@ -733,13 +1270,7 @@
+@@ -733,13 +1268,7 @@
          return NGX_ERROR;
      }
  
@@ -1179,7 +1177,7 @@ diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_common.h b/ngx_lua-0.10.21/src/ngx_
          u_char                              *src_key;
 diff -ruN a/ngx_lua-0.10.21/src/ngx_http_lua_module.c b/ngx_lua-0.10.21/src/ngx_http_lua_module.c
 --- a/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-02 10:58:50.050203715 +0800
-+++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-05 07:01:11.798290942 +0800
++++ b/ngx_lua-0.10.21/src/ngx_http_lua_module.c	2022-12-05 18:22:15.351308080 +0800
 @@ -1117,6 +1117,9 @@
       *      lscf->srv.ssl_session_fetch_src = { 0, NULL };
       *      lscf->srv.ssl_session_fetch_src_key = NULL;


### PR DESCRIPTION
See https://github.com/Kong/kong/issues/9582, test cases: https://github.com/Kong/kong/pull/9856.

The point is `cpool_crc32` in C land.

`balancer.lua`
* remove the usage of crc32 hash
* pass `cpool_name` `cpool_name_len` to C land
* default pool name is an empty string

`ngx_http_lua_balancer.c`
* remove field `crc32` and `cpool_crc32`
* new field `cpool_name` to store pool name string
* `ngx_http_lua_ffi_balancer_set_current_peer`: allocate memory and copy pool name
* `ngx_http_lua_ffi_balancer_enable_keepalive`: set default pool name to `bp->host`
* `ngx_http_lua_balancer_create_keepalive_pool`: 
  * use pool name to index upool
  * allocate memory with `lua_newuserdata`, copy pool name, then set to upool
* `ngx_http_lua_balancer_get_keepalive_pool`: use pool name to index upool
* `ngx_http_lua_balancer_free_keepalive_pool`: get pool name and set to nil
