### PR TITLE
fix(rhel): drop the last digit on rhel naming

### DIFF
--- a/fpm-entrypoint.sh
+++ b/fpm-entrypoint.sh
@@ -57,7 +57,7 @@ if [ "$PACKAGE_TYPE" == "deb" ]; then
   OUTPUT_FILE_SUFFIX=".${RESTY_IMAGE_TAG}"
 elif [ "$PACKAGE_TYPE" == "rpm" ]; then
   FPM_PARAMS="-d pcre -d perl -d perl-Time-HiRes -d zlib -d zlib-devel"
-  OUTPUT_FILE_SUFFIX=".rhel${RESTY_IMAGE_TAG}"
+  OUTPUT_FILE_SUFFIX=".rhel${RESTY_IMAGE_TAG%%.*}"
   if [ "$RESTY_IMAGE_TAG" == "7" ]; then
     FPM_PARAMS="$FPM_PARAMS -d hostname"
   fi


### PR DESCRIPTION
Tested locally.

```
export PACKAGE_TYPE=rpm RESTY_IMAGE_BASE=rhel RESTY_IMAGE_TAG=8.6
make package-kong
... snip ...
ls output 
kong-3.1.0.rhel8.amd64.rpm
```