### PR TITLE
fix(arm64): shrink cargo mem footprint

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -482,6 +482,42 @@ main() {
     exit 0
   fi
 
+  if [ $ATC_ROUTER != 0 ]; then
+    pushd $DOWNLOAD_CACHE/atc-router
+      warn "building dynamic library for atc-router..."
+
+      # the env script adds the cargo bin dir to PATH if missing
+      which cargo > /dev/null || source "${CARGO_HOME:-$HOME/.cargo}"/env
+
+      if [ "$(arch)" == "aarch64" ]; then
+        # rust target aarch64-unknown-linux-gnu must be explicitely told to
+        # produce a statically linked artifact
+        export RUSTFLAGS="-C target-feature=-crt-static"
+
+        # the following options are to save on memory to keep cargo on the
+        # arm64 build from getting OOM killed
+        #
+        # OOM kills look like this in the build output:
+        # 20 96.54 + cargo build --verbose --release
+        # 20 100.9     Updating crates.io index
+        # 20 150.8 Killed
+        #
+        # see also:
+        #  - https://github.com/docker/build-push-action/issues/621
+        #  - https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
+
+        # use git CLI to fetch git-based repos (vs libgit2)
+        export CARGO_NET_GIT_FETCH_WITH_CLI=true
+
+        # fetch crate registry using http (vs git clone)
+        export CARGO_UNSTABLE_SPARSE_REGISTRY=true
+      fi
+
+      # the atc-router makefile also tests for availability of cargo
+      make clean build
+    popd
+  fi
+
   notice "Patching the components now..."
 
   if [ ! -f $OPENRESTY_INSTALL/nginx/sbin/nginx ]; then
@@ -876,21 +912,11 @@ main() {
       fi
 
       if [ $ATC_ROUTER != 0 ]; then
-        local atc_router_install_succeed=0
         pushd $DOWNLOAD_CACHE/atc-router
           warn "installing dynamic library and Lua files for atc-router..."
 
-          # the env script adds the cargo bin dir to PATH if missing
-          which cargo > /dev/null || source "${CARGO_HOME:-$HOME/.cargo}"/env
-
           # the atc-router makefile also tests for availability of cargo
-          make install LUA_LIB_DIR=$OPENRESTY_INSTALL/lualib || atc_router_install_succeed=1
-
-          if [ $atc_router_install_succeed -eq 1 ]; then
-            warn "error while installing atc-router... retrying with RUSTFLAGS='-C target-feature=-crt-static'..."
-            export RUSTFLAGS="-C target-feature=-crt-static"
-            make clean install LUA_LIB_DIR=$OPENRESTY_INSTALL/lualib
-          fi
+          make install LUA_LIB_DIR=$OPENRESTY_INSTALL/lualib
         popd
       fi
     popd


### PR DESCRIPTION
The arm64 build was relatively silently failing while either doing the `cargo build` or just fetching the cargo registry index.
This resolves that issue by taking steps to minimize `cargo`'s memory footprint when building on arm64.

It also splits the `atc-router` install across the openresty build. Building `atc_router.so` before openresty, but __installing__ `atc_router.so` __after__ openresty-- since the openresty files themselves are not strictly required to build atc-router, just for placing the .so in the correct directory (as done by `make`).

Building atc-router sooner in build helps us fail faster when something with the atc-router goes awry.