### PR TITLE
fix(arm64,luajit): bad ptr address with debug mode

### DIFF
--- a/openresty-build-tools/kong-ngx-build
+++ b/openresty-build-tools/kong-ngx-build
@@ -841,7 +841,11 @@ main() {
         if [ $DEBUG == 1 ]; then
           OPENRESTY_OPTS+=('--with-debug')
           OPENRESTY_OPTS+=('--with-no-pool-patch')
-          OPENRESTY_OPTS+=('--with-luajit-xcflags="-DLUAJIT_USE_VALGRIND -DLUA_USE_ASSERT -DLUA_USE_APICHECK -DLUAJIT_USE_SYSMALLOC"')
+          OPENRESTY_OPTS+=('--with-luajit-xcflags="-DLUAJIT_USE_VALGRIND -DLUA_USE_ASSERT -DLUA_USE_APICHECK"')
+          arch=$(uname -m)
+          if [ "$arch" != "aarch64" ]; then
+            OPENRESTY_OPTS+=('--with-luajit-xcflags="-DLUAJIT_USE_SYSMALLOC"')
+          fi
         fi
 
         eval ./configure ${OPENRESTY_OPTS[*]}


### PR DESCRIPTION
We (@dndx ) found that for every Mac M1 aarch64 device (running MacOS or Ubuntu) after building LuaJIT using command such as 
```
./kong-ngx-build -p buildroot --openresty 1.21.4.1 --openssl 1.1.1s --pcre 8.45 -f --debug
```

the LuaJIT binary cannot init properly, which prints

```
./buildroot/openresty/luajit/bin/luajit: cannot create state: not enough memory
```

(this can be reproduced every time)

and @dndx found if `LUAJIT_USE_SYSMALLOC` is enabled in that platform (which is enabled while adding `--debug` flag), system malloc function (`realloc` virtually) returns a address pointer, of which 47 bit is high, while LuaJIT uses this high bit to express some metadata so that this address failed to pass LuaJIT's address check. So, LuaJIT's solution (https://github.com/LuaJIT/LuaJIT/issues/49) is to use `mmap` which allow us to specific an address that high bits are zero.

So we removed `DLUAJIT_USE_SYSMALLOC` when the architecture is `aarch64` to ensure LuaJIT get a legal address.