### PR TITLE
fix(test): Enable Alpine Smoke Tests

### DIFF
--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -1,9 +1,9 @@
 set -x
 
-if \
-  [ "$RESTY_IMAGE_BASE" == 'rhel' ] || \
-  [[ "$RESTY_IMAGE_BASE" == *'/ubi'* ]] || \
-  [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]]
+if
+  [ "$RESTY_IMAGE_BASE" == 'rhel' ] ||
+    [[ "$RESTY_IMAGE_BASE" == *'/ubi'* ]] ||
+    [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]]
 then
   major="${RESTY_IMAGE_TAG%%.*}"
   IMAGE_BASE="registry.access.redhat.com/ubi${major}/ubi"
@@ -23,16 +23,16 @@ DOCKER_SYSTEM_ARCHITECTURE="${DOCKER_SYSTEM_ARCHITECTURE:-$(
 KONG_ARCHITECTURE='amd64'
 
 case "_${DOCKER_SYSTEM_ARCHITECTURE}" in
-  _aarch64|_arm64)
-    BASE_DOCKER_PLATFORM='linux/arm64/v8'
-    ;;
-  _x86_64|_amd64)
-    BASE_DOCKER_PLATFORM='linux/amd64'
-    ;;
-  _|_*)
-    # docker run allows this to be an empty string (aka default platform)
-    BASE_DOCKER_PLATFORM=''
-    ;;
+_aarch64 | _arm64)
+  BASE_DOCKER_PLATFORM='linux/arm64/v8'
+  ;;
+_x86_64 | _amd64)
+  BASE_DOCKER_PLATFORM='linux/amd64'
+  ;;
+_ | _*)
+  # docker run allows this to be an empty string (aka default platform)
+  BASE_DOCKER_PLATFORM=''
+  ;;
 esac
 
 docker run \
@@ -92,12 +92,13 @@ if [[ "$RESTY_IMAGE_BASE" != "alpine" ]]; then
   docker exec ${USE_TTY} user-validation-tests /bin/bash -c "getent group kong"
   docker exec ${USE_TTY} user-validation-tests /bin/bash -c "cat /etc/passwd | grep kong | grep -q /bin/sh"
 
-  if \
-    [[ "$RESTY_IMAGE_BASE" == "amazonlinux" ]] || \
-    [ "$RESTY_IMAGE_BASE" == 'rhel' ] || \
-    [[ "$RESTY_IMAGE_BASE" == *'/ubi'* ]] || \
-    [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]] \
-  ; then
+  if
+    [[ "$RESTY_IMAGE_BASE" == "amazonlinux" ]] ||
+      [ "$RESTY_IMAGE_BASE" == 'rhel' ] ||
+      [[ "$RESTY_IMAGE_BASE" == *'/ubi'* ]] ||
+      [[ "$RESTY_IMAGE_BASE" == *'redhat'* ]] \
+      ;
+  then
     # Needed to run `su`
     docker exec ${USE_TTY} user-validation-tests /bin/bash -c "yum install -y util-linux"
 

--- a/test/tests/01-package/run.sh
+++ b/test/tests/01-package/run.sh
@@ -90,6 +90,10 @@ if [[ "$PACKAGE_TYPE" == "apk" ]]; then
   docker exec ${USE_TTY} user-validation-tests "$_SHELL" -xc "ln -s /usr/local/openresty/nginx/sbin/nginx  /usr/local/bin/nginx"
 fi
 
+# ensure kong version workers and reports expected version
+docker exec ${USE_TTY} user-validation-tests "$_SHELL" -xc "kong version"
+docker exec ${USE_TTY} user-validation-tests "$_SHELL" -xc "kong version | sed 's/[a-zA-Z\ ]//g' | grep -E \"^${KONG_VERSION}\$\""
+
 # These files should have 'kong:kong' ownership
 files=(
   "/etc/kong/"


### PR DESCRIPTION
To match the rest of the platforms.

This seems like it was work that was meant to have been come back to, but never was.
The origins for this work date back to: https://github.com/Kong/kong-build-tools/pull/339