### PR TITLE
[Backport release/2.8.x] chore(patches): fix ldoc intermittent fail caused by LuaJIT

### DIFF
--- a/openresty-patches/patches/1.19.9.1/LuaJIT-2.1-20210510_04_ldoc_error_fix.patch
+++ b/openresty-patches/patches/1.19.9.1/LuaJIT-2.1-20210510_04_ldoc_error_fix.patch
@@ -1,0 +1,22 @@
+From 65c849390702b1150d52e64db86cbc6b3c98413e Mon Sep 17 00:00:00 2001
+From: Mike Pall <mike>
+Date: Thu, 9 Nov 2023 11:02:36 +0100
+Subject: [PATCH] Invalidate SCEV entry when returning to lower frame.
+
+Thanks to Zhongwei Yao. #1115
+---
+ src/lj_record.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/LuaJIT-2.1-20210510/src/lj_record.c b/LuaJIT-2.1-20210510/src/lj_record.c
+index a49f942a..0122105b 100644
+--- a/LuaJIT-2.1-20210510/src/lj_record.c
++++ b/LuaJIT-2.1-20210510/src/lj_record.c
+@@ -891,6 +891,7 @@ void lj_record_ret(jit_State *J, BCReg rbase, ptrdiff_t gotresults)
+       emitir(IRTG(IR_RETF, IRT_PGC), trpt, trpc);
+       J->retdepth++;
+       J->needsnap = 1;
++      J->scev.idx = REF_NIL;
+       lj_assertJ(J->baseslot == 1+LJ_FR2, "bad baseslot for return");
+       /* Shift result slots up and clear the slots of the new frame below. */
+       memmove(J->base + cbase, J->base-1-LJ_FR2, sizeof(TRef)*nresults);


### PR DESCRIPTION
backport from https://github.com/Kong/kong/pull/11983.

Fix #[KAG-1761](https://konghq.atlassian.net/browse/KAG-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[KAG-1761]: https://konghq.atlassian.net/browse/KAG-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ